### PR TITLE
Implement locale system with a basic en locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ esday('2024-12-10').set('year', 2025).add(1, 'month').isToday()
 
 ## Differences with Day.js
 
-- **locale**: esday core does not support locales, localizied formats are provided by plugins.
+- **default start of week**: esday uses Monday as the default week start day (accroding to [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html)).
 
 ## License
 

--- a/src/core/EsDay.ts
+++ b/src/core/EsDay.ts
@@ -5,6 +5,7 @@ import * as C from './constant'
 import { addImpl } from './Impl/add'
 import { formatImpl } from './Impl/format'
 import { startOfImpl } from './Impl/startOf'
+import { getLocale } from './locale'
 import { parseDate } from './parseDate'
 import { callDateGetOrSet, getAllFieldsInDate, prettyUnit } from './utils'
 
@@ -23,6 +24,7 @@ export class EsDay {
   private $d!: Date
   // utc mode
   private $u = false
+  private $l = 'en'
   constructor(d: Exclude<DateType, EsDay>, utc: boolean, ...others: any[]) {
     this.parse(d, utc, ...others)
   }
@@ -30,6 +32,10 @@ export class EsDay {
   private parse(d: Exclude<DateType, EsDay>, utc: boolean, ..._others: any[]) {
     this.$d = parseDate(d)
     this.$u = utc
+  }
+
+  private $locale() {
+    return getLocale(this.$l)
   }
 
   // return utc instance

--- a/src/core/Impl/startOf.ts
+++ b/src/core/Impl/startOf.ts
@@ -21,6 +21,8 @@ export function startOfImpl(that: EsDay, unit: UnitType, reverse = false) {
   }
 
   const $M = callDateGetOrSet(result, 'Month', utc)
+  const $D = callDateGetOrSet(result, 'Date', utc)
+  const $W = callDateGetOrSet(result, 'Day', utc)
 
   switch (prettyUnit(unit)) {
     case C.Y:
@@ -33,9 +35,11 @@ export function startOfImpl(that: EsDay, unit: UnitType, reverse = false) {
       break
     case C.W:
     {
-      const dayOfWeek = callDateGetOrSet(result, 'Day', utc)
-      const diff = (dayOfWeek < 1 ? 7 : 0) + dayOfWeek - (reverse ? 6 : 0)
-      callDateGetOrSet(result, 'Date', utc, callDateGetOrSet(result, 'Date', utc) - diff)
+      // default start of week is Monday
+      // according to ISO 8601
+      const weekStart = that['$locale']().weekStart || 1
+      const diff = ($W < weekStart ? $W + 7 : $W) - weekStart
+      instanceFactory(reverse ? $D + (6 - diff) : $D - diff, $M)
       instanceFactorySet('Hours', 0)
       break
     }

--- a/src/core/locale.ts
+++ b/src/core/locale.ts
@@ -1,0 +1,12 @@
+import type { Locale } from '~/types'
+import en from '~/locale/en'
+
+const LocaleStore: Map<string, Locale> = new Map()
+
+export function getLocale(name: string): Locale {
+  return LocaleStore.get(name) || en
+}
+
+export function registerLocale(locale: Locale): void {
+  LocaleStore.set(locale.name, locale)
+}

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -1,0 +1,14 @@
+// English [en]
+
+import type { Locale } from '~/types'
+
+export default {
+  name: 'en',
+  weekdays: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+  ordinal: (n) => {
+    const s = ['th', 'st', 'nd', 'rd']
+    const v = n % 100
+    return `[${n}${(s[(v - 20) % 10] || s[v] || s[0])}]`
+  },
+} as Locale

--- a/test/startOf.test.ts
+++ b/test/startOf.test.ts
@@ -1,22 +1,48 @@
 import { esday } from 'esday'
-import { expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-it('start of', () => {
-  expect(esday('2024-01-05 12:34:56').startOf('year').format('YYYY-MM-DD')).toBe('2024-01-01')
-  expect(esday('2024-01-05 12:34:56').startOf('month').format('YYYY-MM-DD')).toBe('2024-01-01')
-  expect(esday('2024-01-05 12:34:56').startOf('week').format('YYYY-MM-DD')).toBe('2023-12-31')
-  expect(esday('2024-01-05 12:34:56').startOf('day').format('YYYY-MM-DD')).toBe('2024-01-05')
-  expect(esday('2024-01-05 12:34:56').startOf('hour').format('YYYY-MM-DD HH:mm')).toBe('2024-01-05 12:00')
-  expect(esday('2024-01-05 12:34:56').startOf('minute').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-01-05 12:34:00')
-  expect(esday('2024-01-05 12:34:56').startOf('second').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-01-05 12:34:56')
+describe('startOf', () => {
+  const inst = esday('2024-01-05 12:34:56')
+  it('on unit year', () => {
+    expect(inst.startOf('year').format('YYYY-MM-DD')).toBe('2024-01-01')
+  })
+
+  it('on unit month', () => {
+    expect(inst.startOf('month').format('YYYY-MM-DD')).toBe('2024-01-01')
+  })
+
+  it('on unit week', () => {
+    expect(inst.startOf('week').format('YYYY-MM-DD')).toBe('2024-01-01')
+  })
+
+  it('on unit day', () => {
+    expect(inst.startOf('day').format('YYYY-MM-DD')).toBe('2024-01-05')
+  })
+
+  it('on unit hour', () => {
+    expect(inst.startOf('hour').format('YYYY-MM-DD HH:mm')).toBe('2024-01-05 12:00')
+  })
 })
 
-it('end of', () => {
-  expect(esday('2024-01-05 12:34:56').endOf('year').format('YYYY-MM-DD')).toBe('2024-12-31')
-  expect(esday('2024-01-05 12:34:56').endOf('month').format('YYYY-MM-DD')).toBe('2024-01-31')
-  expect(esday('2024-01-05 12:34:56').endOf('week').format('YYYY-MM-DD')).toBe('2024-01-06')
-  expect(esday('2024-01-05 12:34:56').endOf('day').format('YYYY-MM-DD')).toBe('2024-01-05')
-  expect(esday('2024-01-05 12:34:56').endOf('hour').format('YYYY-MM-DD HH:mm')).toBe('2024-01-05 12:59')
-  expect(esday('2024-01-05 12:34:56').endOf('minute').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-01-05 12:34:59')
-  expect(esday('2024-01-05 12:34:56').endOf('second').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-01-05 12:34:56')
+describe('endOf', () => {
+  const inst = esday('2024-01-05 12:34:56')
+  it('on unit year', () => {
+    expect(inst.endOf('year').format('YYYY-MM-DD')).toBe('2024-12-31')
+  })
+
+  it('on unit month', () => {
+    expect(inst.endOf('month').format('YYYY-MM-DD')).toBe('2024-01-31')
+  })
+
+  it('on unit week', () => {
+    expect(inst.endOf('week').format('YYYY-MM-DD')).toBe('2024-01-07')
+  })
+
+  it('on unit day', () => {
+    expect(inst.endOf('day').format('YYYY-MM-DD')).toBe('2024-01-05')
+  })
+
+  it('on unit hour', () => {
+    expect(inst.endOf('hour').format('YYYY-MM-DD HH:mm')).toBe('2024-01-05 12:59')
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     "esModuleInterop": true,
     "isolatedModules": true
   },
-  "exclude": ["dist"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,7 +8,7 @@ function generateConfig(jsx: boolean): Options {
     format: 'esm',
     clean: true,
     dts: !jsx,
-    entry: ['src/index.ts', 'src/plugins/*/index.ts'],
+    entry: ['src/index.ts', 'src/plugins/*/index.ts', 'src/locale/*.ts'],
     outDir: 'dist/',
     treeshake: { preset: 'smallest' },
     replaceNodeEnv: true,


### PR DESCRIPTION
- Implement locale types for #5.  
- Enhance the `startOf` method to satisfy locale requirements for #5.  
- Set Monday as the default start of the week (ISO 8601), differing from Day.js.