### PR TITLE
Add script to prepare a release (bump version, create changelog)

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "subject-max-length": [2, "always", 120],
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test"
+      ]
+    ]
+  }
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+pnpm exec commitlint --edit $1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esday",
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A simple date library fully written in TypeScript",
   "license": "MIT",
   "homepage": "https://github.com/g-mero/esday",
@@ -38,21 +38,42 @@
     "test": "vitest",
     "test:ui": "vitest --ui --api 9527",
     "test:run": "vitest run",
+    "release": "commit-and-tag-version -i CHANGELOG.md --same-file",
+    "lint-commits": "commitlint --from b4c0a8614dd7d9997 --to HEAD --verbose",
     "copypkg": "cpy package.json dist/ && cpy README.md dist/ ",
-    "pub": "pnpm build && pnpm copypkg && cd dist && pnpm publish"
+    "pub": "pnpm build && pnpm copypkg && cd dist && pnpm publish",
+    "prepare": "husky"
   },
   "dependencies": {
     "radash": "^12.1.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^3",
+    "@commitlint/cli": "^19.6.1",
+    "@commitlint/config-conventional": "^19.6.0",
     "@types/node": "^22.5.2",
     "@vitest/ui": "latest",
+    "commit-and-tag-version": "^12.5.0",
     "cpy-cli": "^5.0.0",
     "eslint": "^9",
+    "husky": "^9.1.7",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4",
     "vite": "latest",
     "vitest": "latest"
+  },
+  "commit-and-tag-version": {
+    "packageFiles": [
+      {
+        "filename": "package.json",
+        "type": "json"
+      }
+    ],
+    "bumpFiles": [
+      {
+        "filename": "package.json",
+        "type": "json"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Add a script to prepare everything for a release:
+ bump version
+ create / update changelog file based on the commit messages.

The commit messages must follow some rules:
`<type>: <commit-message-less-than-120-chars>`

Optionally there can be a body and / or a footeer
```
<type>: <commit-message-less-than-120-chars>

<body line(s)

<footer line>
```
or
```
<type>: <commit-message-less-than-120-chars>

<footer line(s)>
```

The footer is used to signal breaking changes; this way the major version number of the package is increased. An example could be:
`BREAKING CHANGE: what resulted in a breaking change`

Using husky to automatically lint commit messages to make sure that the message has the required format.
For more details about the required format of the commit message see: https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional