### PR TITLE
add plugin locale to support locale

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ export default antfu({
     'no-console': 'warn',
     'ts/no-unused-expressions': 'off',
     'ts/no-empty-object-type': 'off',
+    'ts/ban-ts-comment': 'off',
     'unused-imports/no-unused-imports': 'error',
     'unicorn/consistent-function-scoping': 'off',
   },

--- a/src/core/Impl/startOf.ts
+++ b/src/core/Impl/startOf.ts
@@ -21,6 +21,8 @@ export function startOfImpl(that: EsDay, unit: UnitType, reverse = false) {
   }
 
   const $M = callDateGetOrSet(result, 'Month', utc)
+  const $D = callDateGetOrSet(result, 'Date', utc)
+  const $W = callDateGetOrSet(result, 'Day', utc)
 
   switch (prettyUnit(unit)) {
     case C.Y:
@@ -33,9 +35,12 @@ export function startOfImpl(that: EsDay, unit: UnitType, reverse = false) {
       break
     case C.W:
     {
-      const dayOfWeek = callDateGetOrSet(result, 'Day', utc)
-      const diff = (dayOfWeek < 1 ? 7 : 0) + dayOfWeek - (reverse ? 6 : 0)
-      callDateGetOrSet(result, 'Date', utc, callDateGetOrSet(result, 'Date', utc) - diff)
+      // default start of week is Monday
+      // according to ISO 8601
+      const dayOfWeekMonday = 1
+      const weekStart = dayOfWeekMonday
+      const diff = ($W < weekStart ? $W + 7 : $W) - weekStart
+      instanceFactory(reverse ? $D + (6 - diff) : $D - diff, $M)
       instanceFactorySet('Hours', 0)
       break
     }

--- a/src/core/Impl/startOf.ts
+++ b/src/core/Impl/startOf.ts
@@ -37,8 +37,7 @@ export function startOfImpl(that: EsDay, unit: UnitType, reverse = false) {
     {
       // default start of week is Monday
       // according to ISO 8601
-      const dayOfWeekMonday = 1
-      const weekStart = dayOfWeekMonday
+      const weekStart = C.INDEX_MONDAY
       const diff = ($W < weekStart ? $W + 7 : $W) - weekStart
       instanceFactory(reverse ? $D + (6 - diff) : $D - diff, $M)
       instanceFactorySet('Hours', 0)

--- a/src/core/constant.ts
+++ b/src/core/constant.ts
@@ -9,6 +9,8 @@ export const MILLISECONDS_A_HOUR = SECONDS_A_HOUR * MILLISECONDS_A_SECOND
 export const MILLISECONDS_A_DAY = SECONDS_A_DAY * MILLISECONDS_A_SECOND
 export const MILLISECONDS_A_WEEK = SECONDS_A_WEEK * MILLISECONDS_A_SECOND
 
+export const INDEX_MONDAY = 1
+
 // English locales
 // 'as const' is required to make these values usable as units
 export const MS = 'millisecond' as const

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -1,7 +1,7 @@
 import type { DateType, EsDayFactory } from '~/types'
 import { EsDay } from './EsDay'
 
-// @ts-expect-error plugin declare may cause ts-type-check error, but it's ok
+// @ts-ignore plugin declare may cause ts-type-checke error, but it's ok
 const esday: EsDayFactory = (d?: DateType, ...others: any[]) => {
   if (d instanceof EsDay) {
     return d.clone()

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -1,6 +1,7 @@
 import type { DateType, EsDayFactory } from '~/types'
 import { EsDay } from './EsDay'
 
+// @ts-expect-error plugin declare may cause ts-type-check error, but it's ok
 const esday: EsDayFactory = (d?: DateType, ...others: any[]) => {
   if (d instanceof EsDay) {
     return d.clone()

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,0 +1,62 @@
+// English [en]
+
+import type { Locale } from '~/types'
+
+const localeEn: Locale = {
+  name: 'en',
+  weekdays: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+  weekdaysShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+  weekdaysMin: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+  monthsShort: [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ],
+  weekStart: 1,
+  yearStart: 4,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm',
+  },
+  relativeTime: {
+    future: 'in %s',
+    past: '%s ago',
+    s: 'a few seconds',
+    m: 'a minute',
+    mm: '%d minutes',
+    h: 'an hour',
+    hh: '%d hours',
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years',
+  },
+  meridiem: (hour: number, minute: number, isLowercase: boolean) => {
+    const m = (hour < 12 ? 'AM' : 'PM')
+    return isLowercase ? m.toLowerCase() : m
+  },
+  ordinal: (n) => {
+    const s = ['th', 'st', 'nd', 'rd']
+    const v = n % 100
+    return `[${n}${(s[(v - 20) % 10] || s[v] || s[0])}]`
+  },
+  invalidDate: 'Invalid date',
+}
+
+export default localeEn

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -1,0 +1,68 @@
+import type { Locale } from '~/types'
+
+const localeZh: Locale = {
+  name: 'zh',
+  weekdays: ['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六'],
+  weekdaysShort: ['周日', '周一', '周二', '周三', '周四', '周五', '周六'],
+  weekdaysMin: ['日', '一', '二', '三', '四', '五', '六'],
+  months: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
+  monthsShort: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+  ordinal: (number, period) => {
+    switch (period) {
+      case 'W':
+        return `${number}周`
+      default:
+        return `${number}日`
+    }
+  },
+  weekStart: 1,
+  yearStart: 4,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'YYYY/MM/DD',
+    LL: 'YYYY年M月D日',
+    LLL: 'YYYY年M月D日Ah点mm分',
+    LLLL: 'YYYY年M月D日ddddAh点mm分',
+    l: 'YYYY/M/D',
+    ll: 'YYYY年M月D日',
+    lll: 'YYYY年M月D日 HH:mm',
+    llll: 'YYYY年M月D日dddd HH:mm',
+  },
+  relativeTime: {
+    future: '%s后',
+    past: '%s前',
+    s: '几秒',
+    m: '1 分钟',
+    mm: '%d 分钟',
+    h: '1 小时',
+    hh: '%d 小时',
+    d: '1 天',
+    dd: '%d 天',
+    M: '1 个月',
+    MM: '%d 个月',
+    y: '1 年',
+    yy: '%d 年',
+  },
+  meridiem: (hour, minute) => {
+    const hm = (hour * 100) + minute
+    if (hm < 600) {
+      return '凌晨'
+    }
+    else if (hm < 900) {
+      return '早上'
+    }
+    else if (hm < 1100) {
+      return '上午'
+    }
+    else if (hm < 1300) {
+      return '中午'
+    }
+    else if (hm < 1800) {
+      return '下午'
+    }
+    return '晚上'
+  },
+}
+
+export default localeZh

--- a/src/plugins/locale/index.ts
+++ b/src/plugins/locale/index.ts
@@ -1,0 +1,101 @@
+/* eslint-disable dot-notation */
+import type { EsDayPlugin, Locale, UnitType } from 'esday'
+import * as C from '~/core/constant'
+import { prettyUnit, undefinedOr } from '~/core/utils'
+import en from '~/locales/en'
+
+const LocaleStore: Map<string, Locale> = new Map()
+
+let $localeGlobal = 'en'
+
+export function getLocale(name: string): Locale {
+  return LocaleStore.get(name) || en
+}
+
+export function registerLocale(locale: Locale, rename?: string): void {
+  LocaleStore.set(rename || locale.name, locale)
+}
+
+declare module 'esday' {
+/*   interface EsDay {
+    $locale: () => Locale
+  } */
+
+  interface EsDay {
+    locale: (localeName: string) => EsDay
+  }
+
+  interface EsDayFactory {
+    /**
+     * use locale as global
+     */
+    locale: (localeName: string) => EsDayFactory
+    /**
+     * register locale
+     */
+    registerLocale: (locale: Locale, rename?: string) => EsDayFactory
+  }
+}
+
+export const localePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
+  // @ts-expect-error $locale is private method
+  dayClass.prototype.$locale = function () {
+    // @ts-expect-error $l is private property
+    return getLocale(this['$l'] || 'en')
+  }
+
+  // add locale method
+  dayClass.prototype.locale = function (localeName: string) {
+    const inst = this.clone()
+    // @ts-expect-error $l is private property
+    inst['$l'] = localeName
+
+    return inst
+  }
+
+  // set $l in clone method
+  const oldClone = dayClass.prototype['clone']
+  dayClass.prototype['clone'] = function () {
+    const inst = oldClone.call(this)
+    // @ts-expect-error $l is private property
+    inst['$l'] = this['$l']
+    return inst
+  }
+
+  // set $l in parse method
+  const oldParse = dayClass.prototype['parse']
+  dayClass.prototype['parse'] = function (d: any, utc: boolean, ...others: any[]) {
+    oldParse.call(this, d, utc, ...others)
+    // @ts-expect-error $l is private property
+    this['$l'] = $localeGlobal
+  }
+
+  // change startOf method
+  const oldStartOf = dayClass.prototype['startOf']
+  dayClass.prototype['startOf'] = function (unit: UnitType) {
+    const p = prettyUnit(unit)
+    const inst = oldStartOf.call(this, unit)
+    if (p === C.W) {
+      // default start of week is Monday
+      const defaultStartOfWeek = 1
+      // @ts-expect-error $locale is private method
+      const weekStart = undefinedOr(inst.$locale().weekStart, defaultStartOfWeek)
+      const diffToDefault = weekStart - defaultStartOfWeek
+
+      if (diffToDefault !== 0) {
+        return inst.add(diffToDefault, C.D)
+      }
+    }
+    return inst
+  }
+
+  dayFactory.locale = function (localeName: string) {
+    $localeGlobal = localeName
+    return dayFactory
+  }
+
+  dayFactory.registerLocale = function (locale: Locale, rename?: string) {
+    registerLocale(locale, rename)
+    return dayFactory
+  }
+}

--- a/src/plugins/locale/index.ts
+++ b/src/plugins/locale/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable dot-notation */
-import type { EsDayPlugin, Locale, UnitType } from 'esday'
+import type { EsDay, EsDayPlugin, Locale, UnitType } from 'esday'
 import * as C from '~/core/constant'
 import { prettyUnit, undefinedOr } from '~/core/utils'
 import en from '~/locales/en'
@@ -37,11 +37,14 @@ declare module 'esday' {
   }
 }
 
-function getSetPrivateLocaleName(inst: any, v?: string): string {
-  if (v) {
-    inst['$locale_name'] = v
+function getSetPrivateLocaleName(inst: EsDay, newLocaleName?: string): string {
+  if (newLocaleName) {
+    // @ts-expect-error $locale_name is private property
+    inst['$locale_name'] = newLocaleName
   }
-  return inst['$locale_name'] || 'en'
+
+  // @ts-expect-error $locale_name is private property
+  return inst['$locale_name'] || $localeGlobal
 }
 
 export const localePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -1,0 +1,10 @@
+import type { DateType } from './date'
+import type { EsDay } from '~/core'
+
+export type EsDayFactoryParserFn = (d?: DateType, ...others: any[]) => EsDay
+export interface EsDayFactory {
+  (...args: Parameters<EsDayFactoryParserFn>): ReturnType<EsDayFactoryParserFn>
+  utc: EsDayFactoryParserFn
+  extend: <T extends {}>(plugin: EsDayPlugin<T>, option?: T) => EsDayFactory
+}
+export type EsDayPlugin<T extends {}> = (option: T, dayTsClass: typeof EsDay, esday: EsDayFactory) => void

--- a/src/types/date.ts
+++ b/src/types/date.ts
@@ -1,0 +1,21 @@
+import type { EsDay } from '~/core'
+
+export type DateType = EsDay | Date | string | number | number[] | null | undefined | object
+export interface AllDateFields {
+  year: number
+  month: number
+  /**
+   * date in month
+   * 1 ~ 31
+   */
+  date: number
+  /**
+   * day in week
+   * 0 ~ 6
+   */
+  day: number
+  hour: number
+  minute: number
+  second: number
+  millisecond: number
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,39 +1,4 @@
-import type { EsDay } from '~/core/EsDay'
-
+export * from './core'
+export * from './date'
 export * from './locale'
-
-export type DateType = EsDay | Date | string | number | number[] | null | undefined | object
-export type PrettyUnitType = 'date' | 'day' | 'week' | 'month' | 'year'
-  | 'hour' | 'minute' | 'second' | 'millisecond'
-export type PrettyUnit<T extends UnitType> = T extends 'D' ? 'date' :
-  T extends 'w' ? 'week' : T extends 'M' ? 'month' : T extends 'y' ? 'year' :
-    T extends 'h' ? 'hour' : T extends 'm' ? 'minute' : T extends 's' ? 'second' :
-      T extends 'ms' ? 'millisecond' : T extends 'd' ? 'day' : T
-
-export type UnitType = 'y' | 'M' | 'D' | 'w' | 'h' | 'm' | 's' | 'ms' | 'd' | PrettyUnitType
-export interface AllDateFields {
-  year: number
-  month: number
-  /**
-   * date in month
-   * 1 ~ 31
-   */
-  date: number
-  /**
-   * day in week
-   * 0 ~ 6
-   */
-  day: number
-  hour: number
-  minute: number
-  second: number
-  millisecond: number
-}
-
-export type EsDayFactoryParserFn = (d?: DateType, ...others: any[]) => EsDay
-export interface EsDayFactory {
-  (...args: Parameters<EsDayFactoryParserFn>): ReturnType<EsDayFactoryParserFn>
-  utc: EsDayFactoryParserFn
-  extend: <T extends {}>(plugin: EsDayPlugin<T>, option?: T) => EsDayFactory
-}
-export type EsDayPlugin<T extends {}> = (option: T, dayTsClass: typeof EsDay, esday: EsDayFactory) => void
+export * from './unit'

--- a/src/types/unit.ts
+++ b/src/types/unit.ts
@@ -1,0 +1,8 @@
+export type PrettyUnitType = 'date' | 'day' | 'week' | 'month' | 'year'
+  | 'hour' | 'minute' | 'second' | 'millisecond'
+export type PrettyUnit<T extends UnitType> = T extends 'D' ? 'date' :
+  T extends 'w' ? 'week' : T extends 'M' ? 'month' : T extends 'y' ? 'year' :
+    T extends 'h' ? 'hour' : T extends 'm' ? 'minute' : T extends 's' ? 'second' :
+      T extends 'ms' ? 'millisecond' : T extends 'd' ? 'day' : T
+
+export type UnitType = 'y' | 'M' | 'D' | 'w' | 'h' | 'm' | 's' | 'ms' | 'd' | PrettyUnitType

--- a/test/plugins/locale.test.ts
+++ b/test/plugins/locale.test.ts
@@ -49,5 +49,6 @@ describe('esDay locale methods', () => {
     // @ts-expect-error $locale is private method
     expect(dayTest.$locale().weekStart).toBe(0)
     expect(dayTest.startOf('week').format('YYYY-MM-DD')).toBe('2020-12-27')
+    expect(dayTest.endOf('week').format('YYYY-MM-DD')).toBe('2021-01-02')
   })
 })

--- a/test/plugins/locale.test.ts
+++ b/test/plugins/locale.test.ts
@@ -9,12 +9,12 @@ esday.extend(localePlugin)
 describe('factory locale methods', () => {
   it('set locale', () => {
     esday.locale('zh')
-    // @ts-expect-error $l is private property
-    expect(esday()['$l']).toBe('zh')
+    // @ts-expect-error $locale_name is private property
+    expect(esday()['$locale_name']).toBe('zh')
 
     esday.locale('non-exist')
-    // @ts-expect-error $l is private property
-    expect(esday()['$l']).toBe('non-exist')
+    // @ts-expect-error $locale_name is private property
+    expect(esday()['$locale_name']).toBe('non-exist')
   })
 
   it('register locale', () => {
@@ -32,12 +32,12 @@ describe('factory locale methods', () => {
 
 describe('esDay locale methods', () => {
   const day = esday('2021-01-01')
-  it('set locale', () => {
-    // @ts-expect-error $l is private property
-    expect(day['$l']).toBe('en')
+  it('set locale for instance', () => {
+    // @ts-expect-error $locale_name is private property
+    expect(day['$locale_name']).toBe('en')
     const dayZh = day.locale('zh')
-    // @ts-expect-error $l is private property
-    expect(dayZh['$l']).toBe('zh')
+    // @ts-expect-error $locale_name is private property
+    expect(dayZh['$locale_name']).toBe('zh')
   })
 
   it('start of', () => {

--- a/test/plugins/locale.test.ts
+++ b/test/plugins/locale.test.ts
@@ -1,0 +1,53 @@
+/* eslint-disable dot-notation */
+import { esday } from 'esday'
+import { describe, expect, it } from 'vitest'
+import localeZh from '~/locales/zh'
+import { localePlugin } from '~/plugins/locale'
+
+esday.extend(localePlugin)
+
+describe('factory locale methods', () => {
+  it('set locale', () => {
+    esday.locale('zh')
+    // @ts-expect-error $l is private property
+    expect(esday()['$l']).toBe('zh')
+
+    esday.locale('non-exist')
+    // @ts-expect-error $l is private property
+    expect(esday()['$l']).toBe('non-exist')
+  })
+
+  it('register locale', () => {
+    esday.registerLocale(localeZh)
+    esday.locale('zh')
+    // @ts-expect-error $locale is private method
+    expect(esday().$locale()).toBe(localeZh)
+
+    esday.registerLocale(localeZh, 'zh-cn')
+    esday.locale('zh-cn')
+    // @ts-expect-error $locale is private method
+    expect(esday().$locale()).toBe(localeZh)
+  })
+})
+
+describe('esDay locale methods', () => {
+  const day = esday('2021-01-01')
+  it('set locale', () => {
+    // @ts-expect-error $l is private property
+    expect(day['$l']).toBe('en')
+    const dayZh = day.locale('zh')
+    // @ts-expect-error $l is private property
+    expect(dayZh['$l']).toBe('zh')
+  })
+
+  it('start of', () => {
+    esday.registerLocale({
+      name: 'test',
+      weekStart: 0,
+    } as any)
+    const dayTest = day.locale('test')
+    // @ts-expect-error $locale is private method
+    expect(dayTest.$locale().weekStart).toBe(0)
+    expect(dayTest.startOf('week').format('YYYY-MM-DD')).toBe('2020-12-27')
+  })
+})

--- a/test/startOf.test.ts
+++ b/test/startOf.test.ts
@@ -15,20 +15,19 @@ describe('startOf', () => {
     vi.useRealTimers()
   })
 
-  // First day of the week is calculated for the locales starting a week on Sunday
+  // First day of the week is calculated for the locales starting a week on Monday
   it.each([
     { unit: Y, expected: 1672527600000, expectedAsString: '2023-01-01T00:00:00.000' },
     { unit: M, expected: 1698793200000, expectedAsString: '2023-11-01T00:00:00.000' },
     { unit: D, expected: 1700175600000, expectedAsString: '2023-11-17T00:00:00.000' },
     { unit: DATE, expected: 1700175600000, expectedAsString: '2023-11-17T00:00:00.000' },
-    { unit: W, expected: 1699743600000, expectedAsString: '2023-11-12T00:00:00.000' },
+    { unit: W, expected: 1699743600000, expectedAsString: '2023-11-13T00:00:00.000' },
     { unit: H, expected: 1700186400000, expectedAsString: '2023-11-17T03:00:00.000' },
     { unit: MIN, expected: 1700187840000, expectedAsString: '2023-11-17T03:24:00.000' },
     { unit: S, expected: 1700187886000, expectedAsString: '2023-11-17T03:24:46.000' },
-  ])('for "$unit"', ({ unit, expected, expectedAsString }) => {
+  ])('for "$unit"', ({ unit, expectedAsString }) => {
     const resultDate = esday().startOf(unit)
 
-    expect(resultDate.valueOf()).toBe(expected)
     expect(resultDate.format('YYYY-MM-DDTHH:mm:ss.SSS')).toBe(expectedAsString)
   })
 })
@@ -50,14 +49,13 @@ describe('endOf', () => {
     { unit: M, expected: 1701385199999, expectedAsString: '2023-11-30T23:59:59.999' },
     { unit: D, expected: 1700261999999, expectedAsString: '2023-11-17T23:59:59.999' },
     { unit: DATE, expected: 1700261999999, expectedAsString: '2023-11-17T23:59:59.999' },
-    { unit: W, expected: 1700348399999, expectedAsString: '2023-11-18T23:59:59.999' },
+    { unit: W, expected: 1700348399999, expectedAsString: '2023-11-19T23:59:59.999' },
     { unit: H, expected: 1700189999999, expectedAsString: '2023-11-17T03:59:59.999' },
     { unit: MIN, expected: 1700187899999, expectedAsString: '2023-11-17T03:24:59.999' },
     { unit: S, expected: 1700187886999, expectedAsString: '2023-11-17T03:24:46.999' },
-  ])('for "$unit"', ({ unit, expected, expectedAsString }) => {
+  ])('for "$unit"', ({ unit, expectedAsString }) => {
     const resultDate = esday().endOf(unit)
 
-    expect(resultDate.valueOf()).toBe(expected)
     expect(resultDate.format('YYYY-MM-DDTHH:mm:ss.SSS')).toBe(expectedAsString)
   })
 })

--- a/test/startOf.test.ts
+++ b/test/startOf.test.ts
@@ -17,14 +17,14 @@ describe('startOf', () => {
 
   // First day of the week is calculated for the locales starting a week on Monday
   it.each([
-    { unit: Y, expected: 1672527600000, expectedAsString: '2023-01-01T00:00:00.000' },
-    { unit: M, expected: 1698793200000, expectedAsString: '2023-11-01T00:00:00.000' },
-    { unit: D, expected: 1700175600000, expectedAsString: '2023-11-17T00:00:00.000' },
-    { unit: DATE, expected: 1700175600000, expectedAsString: '2023-11-17T00:00:00.000' },
-    { unit: W, expected: 1699743600000, expectedAsString: '2023-11-13T00:00:00.000' },
-    { unit: H, expected: 1700186400000, expectedAsString: '2023-11-17T03:00:00.000' },
-    { unit: MIN, expected: 1700187840000, expectedAsString: '2023-11-17T03:24:00.000' },
-    { unit: S, expected: 1700187886000, expectedAsString: '2023-11-17T03:24:46.000' },
+    { unit: Y, expectedAsString: '2023-01-01T00:00:00.000' },
+    { unit: M, expectedAsString: '2023-11-01T00:00:00.000' },
+    { unit: D, expectedAsString: '2023-11-17T00:00:00.000' },
+    { unit: DATE, expectedAsString: '2023-11-17T00:00:00.000' },
+    { unit: W, expectedAsString: '2023-11-13T00:00:00.000' },
+    { unit: H, expectedAsString: '2023-11-17T03:00:00.000' },
+    { unit: MIN, expectedAsString: '2023-11-17T03:24:00.000' },
+    { unit: S, expectedAsString: '2023-11-17T03:24:46.000' },
   ])('for "$unit"', ({ unit, expectedAsString }) => {
     const resultDate = esday().startOf(unit)
 
@@ -45,14 +45,14 @@ describe('endOf', () => {
   })
 
   it.each([
-    { unit: Y, expected: 1704063599999, expectedAsString: '2023-12-31T23:59:59.999' },
-    { unit: M, expected: 1701385199999, expectedAsString: '2023-11-30T23:59:59.999' },
-    { unit: D, expected: 1700261999999, expectedAsString: '2023-11-17T23:59:59.999' },
-    { unit: DATE, expected: 1700261999999, expectedAsString: '2023-11-17T23:59:59.999' },
-    { unit: W, expected: 1700348399999, expectedAsString: '2023-11-19T23:59:59.999' },
-    { unit: H, expected: 1700189999999, expectedAsString: '2023-11-17T03:59:59.999' },
-    { unit: MIN, expected: 1700187899999, expectedAsString: '2023-11-17T03:24:59.999' },
-    { unit: S, expected: 1700187886999, expectedAsString: '2023-11-17T03:24:46.999' },
+    { unit: Y, expectedAsString: '2023-12-31T23:59:59.999' },
+    { unit: M, expectedAsString: '2023-11-30T23:59:59.999' },
+    { unit: D, expectedAsString: '2023-11-17T23:59:59.999' },
+    { unit: DATE, expectedAsString: '2023-11-17T23:59:59.999' },
+    { unit: W, expectedAsString: '2023-11-19T23:59:59.999' },
+    { unit: H, expectedAsString: '2023-11-17T03:59:59.999' },
+    { unit: MIN, expectedAsString: '2023-11-17T03:24:59.999' },
+    { unit: S, expectedAsString: '2023-11-17T03:24:46.999' },
   ])('for "$unit"', ({ unit, expectedAsString }) => {
     const resultDate = esday().endOf(unit)
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,7 +8,7 @@ function generateConfig(jsx: boolean): Options {
     format: 'esm',
     clean: true,
     dts: !jsx,
-    entry: ['src/index.ts', 'src/plugins/*/index.ts'],
+    entry: ['src/index.ts', 'src/plugins/*/index.ts', 'src/locales/*.ts'],
     outDir: 'dist/',
     treeshake: { preset: 'smallest' },
     replaceNodeEnv: true,


### PR DESCRIPTION
- `esday.locale(name:string)` to set global default locale.
- `esday.registerLocale(locale:Locale,rename?:string)` to register a locale.
- `esday().locale(name:string)` to use locale in a specific instance.