### PR TITLE
Refactor: replace isArray from radash with javascript Array method

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "pub": "pnpm build && pnpm copypkg && cd dist && pnpm publish",
     "prepare": "husky"
   },
-  "dependencies": {
-    "radash": "^12.1.0"
-  },
   "devDependencies": {
     "@antfu/eslint-config": "^3",
     "@commitlint/cli": "^19.6.1",

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,7 +1,6 @@
 /* eslint-disable dot-notation */
 import type { EsDay } from './EsDay'
 import type { AllDateFields, PrettyUnit, UnitType } from '~/types'
-import { isArray } from 'radash'
 import * as C from './constant'
 
 export function prettyUnit<T extends UnitType>(u: T): PrettyUnit<T> {
@@ -30,7 +29,7 @@ export function callDateGetOrSet(date: Date, field: Exclude<DateField, 'Day'>, u
 export function callDateGetOrSet(date: Date, field: Exclude<DateField, 'Day'>, utc: boolean, value: number[]): void
 export function callDateGetOrSet(date: Date, field: DateField | Exclude<DateField, 'Day'>, utc: boolean, value?: number | number[]): number | void {
   if (!isUndefined(value) && field !== 'Day') {
-    date[`set${utc ? 'UTC' : ''}${field}`](...(isArray(value) ? value : [value]) as [number])
+    date[`set${utc ? 'UTC' : ''}${field}`](...(Array.isArray(value) ? value : [value]) as [number])
     return
   }
   return date[`get${utc ? 'UTC' : ''}${field}`]()


### PR DESCRIPTION
Replace isArray function from the radash package with the standard javascript Array.isArray method