### PR TITLE
A minimal change: refactore imports to use 'esday' where possible

### DIFF
--- a/src/plugins/customParseFormat/index.ts
+++ b/src/plugins/customParseFormat/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable dot-notation */
-import type { EsDay } from 'esday'
-import type { DateType, EsDayPlugin } from '~/types'
+import type { DateType, EsDay, EsDayPlugin } from 'esday'
 import { isString } from '~/common'
 
 const formattingTokens

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         "src/*"
       ],
       "esday": [
-        "src/index.ts"
+        "src/index"
       ]
     },
     "types": ["node"],


### PR DESCRIPTION
Refactor: remove unnecessary ".ts" extension in path definition for esday in tsconfig.json
Refactor: use "import xxx from 'esday' wherever it is possible to improve consistency of imports