### PR TITLE
feat: add plugin `weekOfYear` and `weekYear`

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -10,6 +10,7 @@ export const MILLISECONDS_A_DAY = SECONDS_A_DAY * MILLISECONDS_A_SECOND
 export const MILLISECONDS_A_WEEK = SECONDS_A_WEEK * MILLISECONDS_A_SECOND
 
 export const INDEX_MONDAY = 1
+export const INDEX_THURSDAY = 4
 
 // 'as const' is required to make these values usable as units
 export const MS = 'millisecond' as const

--- a/src/plugins/weekOfYear/index.ts
+++ b/src/plugins/weekOfYear/index.ts
@@ -1,0 +1,37 @@
+import type { EsDayPlugin } from 'esday'
+import { C } from '~/common'
+import { INDEX_THURSDAY, MILLISECONDS_A_WEEK } from '~/common/constants'
+
+declare module 'esday' {
+  interface EsDay {
+    week: (() => number) & ((week: number) => EsDay)
+    weeks: (() => number) & ((week: number) => EsDay)
+  }
+}
+
+export const weekOfYearPlugin: EsDayPlugin<{}> = (_, dayClass) => {
+  // @ts-expect-error function is compatible with its overload
+  dayClass.prototype.week = function (week?: number) {
+    if (week) {
+      return this.add((week - this.week()) * 7, C.DAY)
+    }
+    // @ts-expect-error '$locale' is a private method when plugin locale is installed
+    const yearStart = this.$locale?.().yearStart || INDEX_THURSDAY // default to Thursday according to ISO 8601
+    if (this.month() === 11 && this.date() > 25) {
+      const nextYearStartDay = this.startOf(C.YEAR).add(1, C.YEAR).date(yearStart)
+      const thisEndOfWeek = this.endOf(C.WEEK)
+      if (nextYearStartDay.isBefore(thisEndOfWeek)) {
+        return 1
+      }
+    }
+    const yearStartDay = this.startOf(C.YEAR).date(yearStart)
+    const yearStartWeek = yearStartDay.startOf(C.WEEK).subtract(1, C.MS)
+    const diffInWeek = (this.valueOf() - yearStartWeek.valueOf()) / MILLISECONDS_A_WEEK
+    if (diffInWeek < 0) {
+      return this.startOf(C.WEEK).week()
+    }
+    return Math.ceil(diffInWeek)
+  }
+
+  dayClass.prototype.weeks = dayClass.prototype.week
+}

--- a/src/plugins/weekYear/index.ts
+++ b/src/plugins/weekYear/index.ts
@@ -1,0 +1,22 @@
+import type { EsDayPlugin } from 'esday'
+
+declare module 'esday' {
+  interface EsDay {
+    weekYear: () => number
+  }
+}
+
+export const weekYearPlugin: EsDayPlugin<{}> = (_, dayClass) => {
+  dayClass.prototype.weekYear = function () {
+    const month = this.month()
+    const weekOfYear = this.week()
+    const year = this.year()
+    if (weekOfYear === 1 && month === 11) {
+      return year + 1
+    }
+    if (month === 0 && weekOfYear >= 52) {
+      return year - 1
+    }
+    return year
+  }
+}

--- a/test/plugins/weekOfYear.test.ts
+++ b/test/plugins/weekOfYear.test.ts
@@ -1,0 +1,56 @@
+/* eslint-disable dot-notation */
+import { esday } from 'esday'
+import moment from 'moment'
+import { describe, expect, it } from 'vitest'
+import localeZhCn from '~/locales/zh-cn'
+import { localePlugin } from '~/plugins/locale'
+import { weekOfYearPlugin } from '~/plugins/weekOfYear'
+
+// because moment.js's default week start is Sunday (esday's default is Monday),
+// so we need to set both esday and moment.js to use the same locale
+esday.extend(localePlugin).extend(weekOfYearPlugin)
+esday.registerLocale(localeZhCn)
+esday.locale('zh-cn')
+moment.locale('zh-cn')
+
+describe('week plugin', () => {
+  it('should return the correct week number for a date', () => {
+    expect(esday('2024-01-01').week()).toBe(moment('2024-01-01').week())
+    expect(esday('2024-12-31').week()).toBe(moment('2024-12-31').week())
+    expect(esday('2024-06-15').week()).toBe(moment('2024-06-15').week())
+    expect(esday('2025-01-01').week()).toBe(moment('2025-01-01').week())
+  })
+
+  it('should handle year transition correctly', () => {
+    expect(esday('2023-12-31').week()).toBe(moment('2023-12-31').week())
+    expect(esday('2024-01-01').week()).toBe(moment('2024-01-01').week())
+  })
+
+  it('should handle custom start of the year', () => {
+    // Assume the locale plugin is available and `yearStart` is set
+    const customYearStart = 1 // 2nd day of the year
+    const customDay = esday('2023-01-01') // Sunday
+    // @ts-expect-error Mock `$locale` method to return custom `yearStart`
+    customDay['$locale'] = () => ({ yearStart: customYearStart })
+    expect(customDay.week()).toBe(1)
+  })
+
+  it('should set the correct week number and adjust the date', () => {
+    const date = esday('2024-06-15')
+    const weekNumber = 10
+    const adjustedDate = date.week(weekNumber)
+    expect(adjustedDate.week()).toBe(weekNumber)
+    expect(moment(adjustedDate.toISOString()).week()).toBe(weekNumber)
+  })
+
+  it('should handle edge cases around the start and end of the year', () => {
+    const startOfYear = esday('2024-01-01')
+    expect(startOfYear.week()).toBe(moment('2024-01-01').week())
+
+    const endOfYear = esday('2024-12-31')
+    expect(endOfYear.week()).toBe(moment('2024-12-31').week())
+
+    const yearTransition = esday('2024-12-30')
+    expect(yearTransition.week()).toBe(moment('2024-12-30').week())
+  })
+})

--- a/test/plugins/weekOfYear.test.ts
+++ b/test/plugins/weekOfYear.test.ts
@@ -2,16 +2,15 @@
 import { esday } from 'esday'
 import moment from 'moment'
 import { describe, expect, it } from 'vitest'
-import localeZhCn from '~/locales/zh-cn'
+import localeEnUs from '~/locales/en-us'
 import { localePlugin } from '~/plugins/locale'
 import { weekOfYearPlugin } from '~/plugins/weekOfYear'
 
-// because moment.js's default week start is Sunday (esday's default is Monday),
-// so we need to set both esday and moment.js to use the same locale
+// set to 'en-US' to match moment's default locale
+// ! note that change moment's default locale will break browser tests
 esday.extend(localePlugin).extend(weekOfYearPlugin)
-esday.registerLocale(localeZhCn)
-esday.locale('zh-cn')
-moment.locale('zh-cn')
+esday.registerLocale(localeEnUs)
+esday.locale('en-US')
 
 describe('week plugin', () => {
   it('should return the correct week number for a date', () => {
@@ -32,7 +31,7 @@ describe('week plugin', () => {
     const customDay = esday('2023-01-01') // Sunday
     // @ts-expect-error Mock `$locale` method to return custom `yearStart`
     customDay['$locale'] = () => ({ yearStart: customYearStart })
-    expect(customDay.week()).toBe(1)
+    expect(customDay.weeks()).toBe(1)
   })
 
   it('should set the correct week number and adjust the date', () => {

--- a/test/plugins/weekYear.test.ts
+++ b/test/plugins/weekYear.test.ts
@@ -1,16 +1,15 @@
 import { esday } from 'esday'
 import moment from 'moment'
 import { describe, expect, it } from 'vitest'
-import localeZhCn from '~/locales/zh-cn'
+import localeEnUs from '~/locales/en-us'
 import { localePlugin } from '~/plugins/locale'
 import { weekOfYearPlugin } from '~/plugins/weekOfYear'
 import { weekYearPlugin } from '~/plugins/weekYear'
 
 // Extend esday with required plugins and locale
 esday.extend(localePlugin).extend(weekOfYearPlugin).extend(weekYearPlugin)
-esday.registerLocale(localeZhCn)
-esday.locale('zh-cn')
-moment.locale('zh-cn')
+esday.registerLocale(localeEnUs, 'en-us')
+esday.locale('en-us')
 
 describe('weekYear plugin', () => {
   it('should return the correct week year for a date', () => {

--- a/test/plugins/weekYear.test.ts
+++ b/test/plugins/weekYear.test.ts
@@ -1,0 +1,40 @@
+import { esday } from 'esday'
+import moment from 'moment'
+import { describe, expect, it } from 'vitest'
+import localeZhCn from '~/locales/zh-cn'
+import { localePlugin } from '~/plugins/locale'
+import { weekOfYearPlugin } from '~/plugins/weekOfYear'
+import { weekYearPlugin } from '~/plugins/weekYear'
+
+// Extend esday with required plugins and locale
+esday.extend(localePlugin).extend(weekOfYearPlugin).extend(weekYearPlugin)
+esday.registerLocale(localeZhCn)
+esday.locale('zh-cn')
+moment.locale('zh-cn')
+
+describe('weekYear plugin', () => {
+  it('should return the correct week year for a date', () => {
+    expect(esday('2024-01-01').weekYear()).toBe(moment('2024-01-01').weekYear())
+    expect(esday('2024-12-31').weekYear()).toBe(moment('2024-12-31').weekYear())
+    expect(esday('2023-12-31').weekYear()).toBe(moment('2023-12-31').weekYear())
+    expect(esday('2025-01-01').weekYear()).toBe(moment('2025-01-01').weekYear())
+  })
+
+  it('should handle year transition correctly', () => {
+    expect(esday('2023-12-31').weekYear()).toBe(moment('2023-12-31').weekYear())
+    expect(esday('2024-01-01').weekYear()).toBe(moment('2024-01-01').weekYear())
+    expect(esday('2024-12-31').weekYear()).toBe(moment('2024-12-31').weekYear())
+    expect(esday('2025-01-01').weekYear()).toBe(moment('2025-01-01').weekYear())
+  })
+
+  it('should handle edge cases around the start and end of the year', () => {
+    const endOfYear = esday('2024-12-31')
+    expect(endOfYear.weekYear()).toBe(moment('2024-12-31').weekYear())
+
+    const startOfYear = esday('2024-01-01')
+    expect(startOfYear.weekYear()).toBe(moment('2024-01-01').weekYear())
+
+    const yearTransition = esday('2024-12-30')
+    expect(yearTransition.weekYear()).toBe(moment('2024-12-30').weekYear())
+  })
+})


### PR DESCRIPTION
- default start week of a year should contain Thursday (ISO 8601)