### PR TITLE
feat: add method to change default value

### DIFF
--- a/src/common/default-values.ts
+++ b/src/common/default-values.ts
@@ -1,0 +1,12 @@
+import { isUndefined } from './is'
+
+const defaultValues: Map<string, number> = new Map()
+
+export function defaultVal(key: string): number
+export function defaultVal(key: string, value: number): void
+export function defaultVal(key: string, value?: number): number | void {
+  if (!isUndefined(value)) {
+    defaultValues.set(key, value)
+  }
+  return defaultValues.get(key)
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -2,6 +2,7 @@ import C from './constants'
 
 export { C }
 export * from './date-fields'
+export * from './default-values'
 export * from './esday-inst'
 export * from './is'
 export * from './str-utils'

--- a/src/core/EsDay.ts
+++ b/src/core/EsDay.ts
@@ -2,7 +2,7 @@
 import type { UnitDate, UnitDay, UnitHour, UnitMin, UnitMonth, UnitMs, UnitSecond, UnitWeek, UnitYear } from '~/common'
 import type { DateType, UnitType } from '~/types'
 import type { SimpleObject } from '~/types/util-types'
-import { C, prettyUnit } from '~/common'
+import { C, defaultVal, prettyUnit } from '~/common'
 import { getUnitInDate, setUnitInDate } from '~/common/date-fields'
 import { esday } from '.'
 import { addImpl } from './Impl/add'
@@ -161,3 +161,5 @@ helperNames.forEach((key) => {
     }
   }
 })
+
+defaultVal('weekStart', 1)

--- a/src/core/Impl/startOf.ts
+++ b/src/core/Impl/startOf.ts
@@ -1,7 +1,7 @@
 import type { EsDay } from 'esday'
 import type { UnitWeek } from '~/common'
 import type { UnitType } from '~/types'
-import { C, prettyUnit } from '~/common'
+import { C, defaultVal, prettyUnit } from '~/common'
 
 export function startOfImpl(that: EsDay, unit: UnitType, reverse = false) {
   const result = that.clone()
@@ -36,9 +36,7 @@ export function startOfImpl(that: EsDay, unit: UnitType, reverse = false) {
       break
     case C.WEEK:
     {
-      // default start of week is Monday
-      // according to ISO 8601
-      const weekStart = C.INDEX_MONDAY
+      const weekStart = defaultVal('weekStart')
       const diff = ($day < weekStart ? $day + 7 : $day) - weekStart
       instanceFactory(reverse ? $date + (6 - diff) : $date - diff, $month)
       instanceFactorySet(C.HOUR, 0)

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -1,6 +1,6 @@
 import type { DateType, EsDayFactory } from '~/types'
 import type { SimpleObject, SimpleType } from '~/types/util-types'
-import { isObject } from '~/common'
+import { defaultVal, isObject } from '~/common'
 import { EsDay } from './EsDay'
 
 // @ts-ignore plugin declare may cause ts-type-checke error, but it's ok
@@ -32,5 +32,7 @@ esday.extend = (plugin, option) => {
   }
   return esday
 }
+
+esday.defaultVal = defaultVal
 
 export { esday }

--- a/src/plugins/locale/index.ts
+++ b/src/plugins/locale/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable dot-notation */
 import type { EsDay, EsDayPlugin, UnitType } from 'esday'
 import type { Locale } from './types'
-import { C, prettyUnit, undefinedOr } from '~/common'
+import { C, defaultVal, prettyUnit, undefinedOr } from '~/common'
 import en from '~/locales/en'
 
 const LocaleStore: Map<string, Locale> = new Map()
@@ -80,27 +80,6 @@ export function cloneLocale(source: Locale): Locale {
   return (cloneObject(source) as Locale)
 }
 
-declare module 'esday' {
-/*   interface EsDay {
-    $locale: () => Locale
-  } */
-
-  interface EsDay {
-    locale: (localeName: string) => EsDay
-  }
-
-  interface EsDayFactory {
-    /**
-     * use locale as global
-     */
-    locale: (localeName: string) => EsDayFactory
-    /**
-     * register locale
-     */
-    registerLocale: (locale: Locale, newName?: string) => EsDayFactory
-  }
-}
-
 function getSetPrivateLocaleName(inst: EsDay, newLocaleName?: string): string {
   if (newLocaleName) {
     inst['$conf']['$locale_name'] = newLocaleName
@@ -144,8 +123,7 @@ export const localePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
   const oldEndOf = dayClass.prototype['endOf']
   const fixDiff = (inst: EsDay, origin: EsDay, unit: UnitType, reverse = false) => {
     if (prettyUnit(unit) === C.WEEK) {
-      // default start of week is Monday
-      const defaultStartOfWeek = C.INDEX_MONDAY
+      const defaultStartOfWeek = defaultVal('weekStart')
       // @ts-expect-error $locale is private method
       const weekStart = undefinedOr(inst.$locale().weekStart, defaultStartOfWeek)
       const $day = origin.day()

--- a/src/plugins/weekOfYear/index.ts
+++ b/src/plugins/weekOfYear/index.ts
@@ -1,5 +1,5 @@
 import type { EsDayPlugin } from 'esday'
-import { C } from '~/common'
+import { C, defaultVal } from '~/common'
 import { INDEX_THURSDAY, MILLISECONDS_A_WEEK } from '~/common/constants'
 
 declare module 'esday' {
@@ -10,13 +10,15 @@ declare module 'esday' {
 }
 
 export const weekOfYearPlugin: EsDayPlugin<{}> = (_, dayClass) => {
+  // according to ISO-8601
+  defaultVal('yearStart', INDEX_THURSDAY)
   // @ts-expect-error function is compatible with its overload
   dayClass.prototype.week = function (week?: number) {
     if (week) {
       return this.add((week - this.week()) * 7, C.DAY)
     }
     // @ts-expect-error '$locale' is a private method when plugin locale is installed
-    const yearStart = this.$locale?.().yearStart || INDEX_THURSDAY // default to Thursday according to ISO 8601
+    const yearStart = this.$locale?.().yearStart || defaultVal('yearStart')
     if (this.month() === 11 && this.date() > 25) {
       const nextYearStartDay = this.startOf(C.YEAR).add(1, C.YEAR).date(yearStart)
       const thisEndOfWeek = this.endOf(C.WEEK)

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -5,6 +5,7 @@ export type EsDayFactoryParserFn = (d?: DateType, ...others: (SimpleType | { [ke
 export interface EsDayFactory {
   (...args: Parameters<EsDayFactoryParserFn>): ReturnType<EsDayFactoryParserFn>
   extend: <T extends {}>(plugin: EsDayPlugin<T>, option?: T) => EsDayFactory
+  defaultVal: ((key: string) => number) & ((key: string, value: number) => void)
 }
 export type EsDayPlugin<T extends {}> = (option: T, dayTsClass: typeof EsDay, esday: EsDayFactory) => void
 export type DateType = EsDay | Date | string | number | number[] | null | undefined | object

--- a/test/plugins/weekOfYear.test.ts
+++ b/test/plugins/weekOfYear.test.ts
@@ -2,15 +2,13 @@
 import { esday } from 'esday'
 import moment from 'moment'
 import { describe, expect, it } from 'vitest'
-import localeEnUs from '~/locales/en-us'
-import { localePlugin } from '~/plugins/locale'
 import { weekOfYearPlugin } from '~/plugins/weekOfYear'
 
 // set to 'en-US' to match moment's default locale
 // ! note that change moment's default locale will break browser tests
-esday.extend(localePlugin).extend(weekOfYearPlugin)
-esday.registerLocale(localeEnUs)
-esday.locale('en-US')
+esday.extend(weekOfYearPlugin)
+esday.defaultVal('weekStart', 0)
+esday.defaultVal('yearStart', 1)
 
 describe('week plugin', () => {
   it('should return the correct week number for a date', () => {

--- a/test/plugins/weekYear.test.ts
+++ b/test/plugins/weekYear.test.ts
@@ -1,15 +1,13 @@
 import { esday } from 'esday'
 import moment from 'moment'
 import { describe, expect, it } from 'vitest'
-import localeEnUs from '~/locales/en-us'
-import { localePlugin } from '~/plugins/locale'
 import { weekOfYearPlugin } from '~/plugins/weekOfYear'
 import { weekYearPlugin } from '~/plugins/weekYear'
 
 // Extend esday with required plugins and locale
-esday.extend(localePlugin).extend(weekOfYearPlugin).extend(weekYearPlugin)
-esday.registerLocale(localeEnUs, 'en-us')
-esday.locale('en-us')
+esday.extend(weekOfYearPlugin).extend(weekYearPlugin)
+esday.defaultVal('weekStart', 0)
+esday.defaultVal('yearStart', 1)
 
 describe('weekYear plugin', () => {
   it('should return the correct week year for a date', () => {


### PR DESCRIPTION
> Provide an easy way to make Esday compatible with original moment and dayjs.

`esday.defaultVal( key:string )` to get default value.
`esday.defaultVal( key:string, value:number )` to change default value.