### PR TITLE
Refactor: replace forEach in tests with it.each

### DIFF
--- a/scripts/skipCI.cjs
+++ b/scripts/skipCI.cjs
@@ -32,6 +32,7 @@ async function main() {
         ),
     )
 
+  // eslint-disable-next-line no-console
   console.log(shouldNotSkipCI ? 'false' : 'true')
 }
 

--- a/test/plugins/isLeapYear.test.ts
+++ b/test/plugins/isLeapYear.test.ts
@@ -6,32 +6,37 @@ import isLeapYearPlugin from '~/plugins/isLeapYear'
 esday.extend(isLeapYearPlugin)
 
 describe('isLeapYear plugin', () => {
-  it('should correctly identify leap years', () => {
-    const leapYears = [2000, 2004, 2020, 2400]
-    leapYears.forEach((year) => {
-      const esdayDate = esday(`${year}-01-01`)
-      const momentDate = moment(`${year}-01-01`)
-      expect(esdayDate.isLeapYear()).toBe(true)
-      expect(esdayDate.isLeapYear()).toBe(momentDate.isLeapYear())
-    })
+  it.each([
+    2000,
+    2004,
+    2020,
+    2400,
+  ])('should correctly identify "%i" as leap year', (year) => {
+    const esdayDate = esday(`${year}-01-01`)
+    const momentDate = moment(`${year}-01-01`)
+    expect(esdayDate.isLeapYear()).toBe(true)
+    expect(esdayDate.isLeapYear()).toBe(momentDate.isLeapYear())
   })
 
-  it('should correctly identify non-leap years', () => {
-    const nonLeapYears = [1900, 2001, 2021, 2100]
-    nonLeapYears.forEach((year) => {
-      const esdayDate = esday(`${year}-01-01`)
-      const momentDate = moment(`${year}-01-01`)
-      expect(esdayDate.isLeapYear()).toBe(false)
-      expect(esdayDate.isLeapYear()).toBe(momentDate.isLeapYear())
-    })
+  it.each([
+    1900,
+    2001,
+    2021,
+    2100,
+  ])('should correctly identify "%i" as non-leap year', (year) => {
+    const esdayDate = esday(`${year}-01-01`)
+    const momentDate = moment(`${year}-01-01`)
+    expect(esdayDate.isLeapYear()).toBe(false)
+    expect(esdayDate.isLeapYear()).toBe(momentDate.isLeapYear())
   })
 
-  it('should work correctly with different months and days', () => {
-    const dates = ['2000-02-29', '2020-12-31', '1900-06-15']
-    dates.forEach((date) => {
-      const esdayDate = esday(date)
-      const momentDate = moment(date)
-      expect(esdayDate.isLeapYear()).toBe(momentDate.isLeapYear())
-    })
+  it.each([
+    '2000-02-29',
+    '2020-12-31',
+    '1900-06-15',
+  ])('should work correctly with different "%s"', (date) => {
+    const esdayDate = esday(date)
+    const momentDate = moment(date)
+    expect(esdayDate.isLeapYear()).toBe(momentDate.isLeapYear())
   })
 })

--- a/test/plugins/isSameOrAfter.test.ts
+++ b/test/plugins/isSameOrAfter.test.ts
@@ -7,25 +7,21 @@ import isSameOrAfterPlugin from '~/plugins/isSameOrAfter'
 esday.extend(isSameOrAfterPlugin)
 
 describe('isSameOrAfter plugin', () => {
-  it('should correctly determine if a date is the same or after another date', () => {
-    const testCases = [
-      { date1: '2025-01-06', date2: '2025-01-06', unit: 'day', expected: true },
-      { date1: '2025-01-06', date2: '2025-01-05', unit: 'day', expected: true },
-      { date1: '2025-01-05', date2: '2025-01-06', unit: 'day', expected: false },
-      { date1: '2025-01-06T12:00:00', date2: '2025-01-06T11:59:59', unit: 'second', expected: true },
-      { date1: '2025-01-06T11:59:58', date2: '2025-01-06T11:59:59', unit: 'second', expected: false },
-    ]
+  it.each([
+    { date1: '2025-01-06', date2: '2025-01-06', unit: 'day', expected: true },
+    { date1: '2025-01-06', date2: '2025-01-05', unit: 'day', expected: true },
+    { date1: '2025-01-05', date2: '2025-01-06', unit: 'day', expected: false },
+    { date1: '2025-01-06T12:00:00', date2: '2025-01-06T11:59:59', unit: 'second', expected: true },
+    { date1: '2025-01-06T11:59:58', date2: '2025-01-06T11:59:59', unit: 'second', expected: false },
+  ])('should correctly determine if "$date1" is the same or after "$date2"', ({ date1, date2, unit, expected }) => {
+    const esDayInstance = esday(date1)
+    const momentInstance = moment(date1)
 
-    testCases.forEach(({ date1, date2, unit, expected }) => {
-      const esDayInstance = esday(date1)
-      const momentInstance = moment(date1)
+    const esDayResult = esDayInstance.isSameOrAfter(date2, unit as UnitType)
+    const momentResult = momentInstance.isSameOrAfter(date2, unit as UnitType)
 
-      const esDayResult = esDayInstance.isSameOrAfter(date2, unit as UnitType)
-      const momentResult = momentInstance.isSameOrAfter(date2, unit as UnitType)
-
-      expect(esDayResult).toBe(expected)
-      expect(esDayResult).toBe(momentResult)
-    })
+    expect(esDayResult).toBe(expected)
+    expect(esDayResult).toBe(momentResult)
   })
 
   it('should handle invalid dates gracefully', () => {

--- a/test/plugins/isSameOrBefore.test.ts
+++ b/test/plugins/isSameOrBefore.test.ts
@@ -7,25 +7,21 @@ import isSameOrBeforePlugin from '~/plugins/isSameOrBefore'
 esday.extend(isSameOrBeforePlugin)
 
 describe('isSameOrBefore plugin', () => {
-  it('should correctly determine if a date is the same or before another date', () => {
-    const testCases = [
-      { date1: '2025-01-06', date2: '2025-01-06', unit: 'day', expected: true },
-      { date1: '2025-01-06', date2: '2025-01-05', unit: 'day', expected: false },
-      { date1: '2025-01-05', date2: '2025-01-06', unit: 'day', expected: true },
-      { date1: '2025-01-06T12:00:00', date2: '2025-01-06T11:59:59', unit: 'second', expected: false },
-      { date1: '2025-01-06T11:59:58', date2: '2025-01-06T11:59:59', unit: 'second', expected: true },
-    ]
+  it.each([
+    { date1: '2025-01-06', date2: '2025-01-06', unit: 'day', expected: true },
+    { date1: '2025-01-06', date2: '2025-01-05', unit: 'day', expected: false },
+    { date1: '2025-01-05', date2: '2025-01-06', unit: 'day', expected: true },
+    { date1: '2025-01-06T12:00:00', date2: '2025-01-06T11:59:59', unit: 'second', expected: false },
+    { date1: '2025-01-06T11:59:58', date2: '2025-01-06T11:59:59', unit: 'second', expected: true },
+  ])('should correctly determine if "$date1" is the same or before "date2"', ({ date1, date2, unit, expected }) => {
+    const esDayInstance = esday(date1)
+    const momentInstance = moment(date1)
 
-    testCases.forEach(({ date1, date2, unit, expected }) => {
-      const esDayInstance = esday(date1)
-      const momentInstance = moment(date1)
+    const esDayResult = esDayInstance.isSameOrBefore(date2, unit as UnitType)
+    const momentResult = momentInstance.isSameOrBefore(date2, unit as UnitType)
 
-      const esDayResult = esDayInstance.isSameOrBefore(date2, unit as UnitType)
-      const momentResult = momentInstance.isSameOrBefore(date2, unit as UnitType)
-
-      expect(esDayResult).toBe(expected)
-      expect(esDayResult).toBe(momentResult)
-    })
+    expect(esDayResult).toBe(expected)
+    expect(esDayResult).toBe(momentResult)
   })
 
   it('should handle invalid dates gracefully', () => {

--- a/test/plugins/minMax.test.ts
+++ b/test/plugins/minMax.test.ts
@@ -6,63 +6,75 @@ import minMaxPlugin from '~/plugins/minMax'
 esday.extend(minMaxPlugin)
 
 describe('minMax plugin', () => {
-  it('should correctly determine the maximum date', () => {
-    const testCases = [
-      ['2025-01-01', '2024-12-31', '2023-06-15'],
-      ['2023-01-01', '2023-12-31'],
-      ['2024-02-29', '2024-02-28', '2024-01-01'], // Leap year edge case
-    ]
-
-    testCases.forEach((dateStrings) => {
+  describe('max', () => {
+    it.each([
+      { dateStrings: ['2025-01-01', '2024-12-31', '2023-06-15'] },
+      { dateStrings: ['2023-01-01', '2023-12-31'] },
+      { dateStrings: ['2024-02-29', '2024-02-28', '2024-01-01'] }, // Leap year edge case
+    ])('should correctly determine the maximum date from "dateStrings"', ({ dateStrings }) => {
       const maxEsDay = esday.max(...dateStrings)
       const maxMoment = moment.max(dateStrings.map(d => moment(d)))
 
-      expect(maxEsDay?.toISOString()).toEqual(maxMoment.toISOString())
+      expect(maxEsDay.toISOString()).toEqual(maxMoment.toISOString())
+    })
+
+    it('should return current time for empty inputs', () => {
+      expect(esday.max().format('YYYY-MM-DD')).toBe(moment.max().format('YYYY-MM-DD'))
+    })
+
+    it('should handle invalid dates gracefully', () => {
+      const testDates = [
+        esday('2025-01-01'),
+        esday('invalid-date'),
+        esday('2024-12-31'),
+      ]
+      const momentDates = [
+        moment('2025-01-01'),
+        moment.invalid(),
+        moment('2024-12-31'),
+      ]
+
+      const maxEsDay = esday.max(testDates)
+      const maxMoment = moment.max(momentDates)
+
+      expect(maxEsDay.isValid()).toBe(false)
+      expect(maxEsDay.isValid()).toBe(maxMoment.isValid())
     })
   })
 
-  it('should correctly determine the minimum date', () => {
-    const testCases = [
-      ['2025-01-01', '2024-12-31', '2023-06-15'],
-      ['2023-01-01', '2023-12-31'],
-      ['2024-02-29', '2024-02-28', '2024-01-01'], // Leap year edge case
-    ]
-
-    testCases.forEach((dateStrings) => {
+  describe('min', () => {
+    it.each([
+      { dateStrings: ['2025-01-01', '2024-12-31', '2023-06-15'] },
+      { dateStrings: ['2023-01-01', '2023-12-31'] },
+      { dateStrings: ['2024-02-29', '2024-02-28', '2024-01-01'] }, // Leap year edge case
+    ])('should correctly determine the minimum date', ({ dateStrings }) => {
       const minEsDay = esday.min(dateStrings)
       const minMoment = moment.min(dateStrings.map(d => moment(d)))
 
       expect(minEsDay.toISOString()).toEqual(minMoment.toISOString())
     })
-  })
 
-  it('should return current time for empty inputs', () => {
-    expect(esday.max().format('YYYY-MM-DD')).toBe(moment.max().format('YYYY-MM-DD'))
-    expect(esday.min().format('YYYY-MM-DD')).toBe(moment.min().format('YYYY-MM-DD'))
-  })
+    it('should return current time for empty inputs', () => {
+      expect(esday.min().format('YYYY-MM-DD')).toBe(moment.min().format('YYYY-MM-DD'))
+    })
 
-  it('should handle invalid dates gracefully', () => {
-    const testDates = [
-      esday('2025-01-01'),
-      esday('invalid-date'),
-      esday('2024-12-31'),
-    ]
-    const momentDates = [
-      moment('2025-01-01'),
-      moment.invalid(),
-      moment('2024-12-31'),
-    ]
+    it('should handle invalid dates gracefully', () => {
+      const testDates = [
+        esday('2025-01-01'),
+        esday('invalid-date'),
+        esday('2024-12-31'),
+      ]
+      const momentDates = [
+        moment('2025-01-01'),
+        moment.invalid(),
+        moment('2024-12-31'),
+      ]
 
-    const maxEsDay = esday.max(testDates)
-    const maxMoment = moment.max(momentDates)
+      const minEsDay = esday.min(testDates)
+      const minMoment = moment.min(momentDates)
 
-    expect(maxEsDay.isValid()).toBe(false)
-    expect(maxEsDay.isValid()).toEqual(maxMoment.isValid())
-
-    const minEsDay = esday.min(testDates)
-    const minMoment = moment.min(momentDates)
-
-    expect(maxEsDay.isValid()).toBe(false)
-    expect(minEsDay.isValid()).toEqual(minMoment.isValid())
+      expect(minEsDay.isValid()).toBe(false)
+      expect(minEsDay.isValid()).toBe(minMoment.isValid())
+    })
   })
 })

--- a/test/plugins/toArray.test.ts
+++ b/test/plugins/toArray.test.ts
@@ -6,22 +6,18 @@ import toArrayPlugin from '~/plugins/toArray'
 esday.extend(toArrayPlugin)
 
 describe('toArray plugin', () => {
-  it('should correctly convert a date to an array', () => {
-    const testDates = [
-      '2025-01-06T12:34:56.789Z',
-      '2000-02-29T23:59:59.999Z', // Leap year edge case
-      '1999-12-31T00:00:00.000Z',
-    ]
+  it.each([
+    '2025-01-06T12:34:56.789Z',
+    '2000-02-29T23:59:59.999Z', // Leap year edge case
+    '1999-12-31T00:00:00.000Z',
+  ])('should correctly convert "%s" to an array', (dateString) => {
+    const esDayInstance = esday(dateString)
+    const momentInstance = moment(dateString)
 
-    testDates.forEach((dateString) => {
-      const esDayInstance = esday(dateString)
-      const momentInstance = moment(dateString)
+    const esDayArray = esDayInstance.toArray()
+    const momentArray = momentInstance.toArray()
 
-      const esDayArray = esDayInstance.toArray()
-      const momentArray = momentInstance.toArray()
-
-      expect(esDayArray).toEqual(momentArray)
-    })
+    expect(esDayArray).toEqual(momentArray)
   })
 
   it('should handle invalid dates gracefully', () => {

--- a/test/plugins/toObject.test.ts
+++ b/test/plugins/toObject.test.ts
@@ -6,42 +6,34 @@ import toObjectPlugin from '~/plugins/toObject'
 esday.extend(toObjectPlugin)
 
 describe('toObject plugin', () => {
-  it('should match moment.toObject for the same date', () => {
-    const testDates = [
-      '2025-01-01T00:00:00.000Z',
-      '2023-06-15T12:34:56.789Z',
-      '1999-12-31T23:59:59.999Z',
-      '1970-01-01T00:00:00.000Z',
-    ]
+  it.each([
+    '2025-01-01T00:00:00.000Z',
+    '2023-06-15T12:34:56.789Z',
+    '1999-12-31T23:59:59.999Z',
+    '1970-01-01T00:00:00.000Z',
+  ])('should handle toObject for "%s" consistently with momentjs', (dateString) => {
+    const esdayDate = esday(dateString)
+    const momentDate = moment(dateString)
 
-    testDates.forEach((dateString) => {
-      const esdayDate = esday(dateString)
-      const momentDate = moment(dateString)
+    const esdayObject = esdayDate.toObject()
+    const momentObject = momentDate.toObject()
 
-      const esdayObject = esdayDate.toObject()
-      const momentObject = momentDate.toObject()
-
-      expect(esdayObject).toEqual(momentObject)
-    })
+    expect(esdayObject).toEqual(momentObject)
   })
 
-  it('should handle edge cases consistently with moment.toObject', () => {
-    const edgeCases = [
-      '1900-02-28T00:00:00.000Z',
-      '2100-02-28T23:59:59.999Z',
-      '2000-02-29T12:00:00.000Z',
-      '2024-02-29T12:00:00.000Z',
-    ]
+  it.each([
+    '1900-02-28T00:00:00.000Z',
+    '2100-02-28T23:59:59.999Z',
+    '2000-02-29T12:00:00.000Z',
+    '2024-02-29T12:00:00.000Z',
+  ])('should handle toObject for edge case "%s" consistently with momentjs', (dateString) => {
+    const esdayDate = esday(dateString)
+    const momentDate = moment(dateString)
 
-    edgeCases.forEach((dateString) => {
-      const esdayDate = esday(dateString)
-      const momentDate = moment(dateString)
+    const esdayObject = esdayDate.toObject()
+    const momentObject = momentDate.toObject()
 
-      const esdayObject = esdayDate.toObject()
-      const momentObject = momentDate.toObject()
-
-      expect(esdayObject).toEqual(momentObject)
-    })
+    expect(esdayObject).toEqual(momentObject)
   })
 
   it('should return consistent results for the current date and time', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,5 +20,12 @@ export default defineConfig({
         { browser: 'webkit' },
       ],
     },
+    onConsoleLog(log) {
+      // HACK suppress moment.js deprecation warning from test file
+      // 'test/plugins/toArray.test.ts > toArray plugin > should handle invalid dates gracefully'
+      if (log.includes('Non RFC2822/ISO date formats are discouraged'))
+        return false
+      return true
+    },
   },
 })


### PR DESCRIPTION
Using 'it.each' generates a log entry for each entry in the array. Therefore we get a detailed log for a failing test, showing exactly which entry was the 'culprit'. And you can start a debug run for exactly 1 entry in the array.

On the other side, using forEach shows only 1 failing test and you have to find out, which value failed.
