### PR TITLE
Docs: add remark on toISOString to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ esday('2024-12-10').set('year', 2025).add(1, 'month').isToday()
 
 ## Differences to Moment.js
 
-- **toString** conforms to Day.js and uses Date.toUTCString() (returning the date in RFC 7231 format 'ddd, DD MMM YYYY HH:mm:ss [GMT]') while moment uses the format 'ddd MMM DD YYYY HH:mm:ss [GMT]ZZ'.
+- **toString**: conforms to Day.js and uses Date.toUTCString() (returning the date in RFC 7231 format 'ddd, DD MMM YYYY HH:mm:ss [GMT]') while moment uses the format 'ddd MMM DD YYYY HH:mm:ss [GMT]ZZ'.
+- **toISOString**: conforms to Day.js and returns 'Invalid Date' when called on an invalid date. In that case moment returns null (see [moment pr#3710](https://github.com/moment/moment/pull/3710)).
 
 ## License
 


### PR DESCRIPTION
Dayjs and moment return different results, when using  toISOString() on an invalid date, To avoid ugly type castings or `if (x !== null)` assertions, we stay with the dayjs way of handling this case.