### PR TITLE
Refactor core module and utc plugin to remove tight coupling between plugins (utc, advancedParse)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,10 @@
 name: Lint
 
+# Prevent that corepack looks for latest version of pnpm
+# HACK to work around issue nodejs/corepack#625
+env:
+  COREPACK_DEFAULT_TO_LATEST: 0
+
 # Controls when the action will run.
 on:
   # Triggers the workflow on pull request events but only for the main branch

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -1,5 +1,10 @@
 name: Test (vitest & playwright - macOS)
 
+# Prevent that corepack looks for latest version of pnpm
+# HACK to work around issue nodejs/corepack#625
+env:
+  COREPACK_DEFAULT_TO_LATEST: 0
+
 concurrency:
   group: macos-test-${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-node.yaml
+++ b/.github/workflows/test-node.yaml
@@ -1,5 +1,10 @@
 name: Test (Vitest)
 
+# Prevent that corepack looks for latest version of pnpm
+# HACK to work around issue nodejs/corepack#625
+env:
+  COREPACK_DEFAULT_TO_LATEST: 0
+
 # Controls when the action will run.
 on:
   # Triggers the workflow on pull request events but only for the main branch

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -1,5 +1,10 @@
 name: Test (vitest & playwright - Windows)
 
+# Prevent that corepack looks for latest version of pnpm
+# HACK to work around issue nodejs/corepack#625
+env:
+  COREPACK_DEFAULT_TO_LATEST: 0
+
 concurrency:
   group: windows-test-${{ github.head_ref }}
   cancel-in-progress: true

--- a/scripts/skipCI.cjs
+++ b/scripts/skipCI.cjs
@@ -22,15 +22,15 @@ async function main() {
 
   const shouldNotSkipCI
     = !changedFiles.length
-    || changedFiles.some(
-      file =>
-        !SKIP_FOLDERS.some(
-          folder =>
-            file.startsWith(`${folder}/`)
-            || file === folder
-            || file.endsWith('.md'),
-        ),
-    )
+      || changedFiles.some(
+        file =>
+          !SKIP_FOLDERS.some(
+            folder =>
+              file.startsWith(`${folder}/`)
+              || file === folder
+              || file.endsWith('.md'),
+          ),
+      )
 
   // eslint-disable-next-line no-console
   console.log(shouldNotSkipCI ? 'false' : 'true')

--- a/src/common/date-fields.ts
+++ b/src/common/date-fields.ts
@@ -14,7 +14,7 @@ const UNIT_FIELD_MAP = {
 } as const
 
 type DateUnit = keyof typeof UNIT_FIELD_MAP
-type DateField<T extends DateUnit > = typeof UNIT_FIELD_MAP[T]
+type DateField<T extends DateUnit> = typeof UNIT_FIELD_MAP[T]
 
 export const prettyUnits = Object.keys(UNIT_FIELD_MAP) as (keyof typeof UNIT_FIELD_MAP)[]
 

--- a/src/core/Impl/parse.ts
+++ b/src/core/Impl/parse.ts
@@ -1,7 +1,4 @@
-import type { EsDay } from 'esday'
-import type { DateType } from '~/types'
 import type { Tuple } from '~/types/util-types'
-import { C, isEmptyObject, isUndefined } from '~/common'
 
 export function parseArrayToDate(dateArray: number[]) {
   const dateArrayTuple: Tuple<number, 7> = [0, 0, 1, 0, 0, 0, 0]
@@ -11,35 +8,4 @@ export function parseArrayToDate(dateArray: number[]) {
     }
   })
   return new Date(...dateArrayTuple)
-}
-
-export function parseImpl(date?: Exclude<DateType, EsDay>, utc = false): Date {
-  if (date instanceof Date)
-    return new Date(date)
-  if (date === null)
-    return new Date(Number.NaN)
-  if (isUndefined(date))
-    return new Date()
-  if (isEmptyObject(date))
-    return new Date()
-  if (Array.isArray(date))
-    return parseArrayToDate(date)
-  if (typeof date === 'string' && !/Z$/i.test(date)) {
-    const d = date.match(C.REGEX_PARSE)
-    if (d) {
-      const Y = Number(d[1])
-      const M = Number(d[2]) - 1 || 0
-      const D = Number(d[3] || 1)
-      const h = Number(d[4] || 0)
-      const m = Number(d[5] || 0)
-      const s = Number(d[6] || 0)
-      const ms = Number((d[7] || '0').substring(0, 3))
-      if (utc) {
-        return new Date(Date.UTC(Y, M, D, h, m, s, ms))
-      }
-      return new Date(Y, M, D, h, m, s, ms)
-    }
-  }
-
-  return new Date(date)
 }

--- a/src/plugins/utc/index.ts
+++ b/src/plugins/utc/index.ts
@@ -121,8 +121,14 @@ const utcPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
   }
 
   // change method 'parse'
-  proto['parse'] = function (date?: DateType) {
-    this['$d'] = this['$parseDate'](date, !!this['$conf'].utc)
+  const oldDateFromDateComponents = proto['dateFromDateComponents']
+  proto['dateFromDateComponents'] = function (Y: number, M: number, D: number, h: number, m: number, s: number, ms: number) {
+    if (this['$conf'].utc) {
+      return new Date(Date.UTC(Y, M, D, h, m, s, ms))
+    }
+    else {
+      return oldDateFromDateComponents(Y, M, D, h, m, s, ms)
+    }
   }
 
   proto.get = function (unit) {

--- a/test/getset.test.ts
+++ b/test/getset.test.ts
@@ -1,5 +1,6 @@
+import type { EsDay } from '~/core'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { type EsDay, esday } from '~/core'
+import { esday } from '~/core'
 
 describe('get', () => {
   const testYear = 2024

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,6 @@
+import type { Options } from 'tsup'
 // tsup.config.ts
-import { defineConfig, type Options } from 'tsup'
+import { defineConfig } from 'tsup'
 
 function generateConfig(jsx: boolean): Options {
   return {


### PR DESCRIPTION
The implementation of the parse method in the core module depends on the knowledge that there is an utc plugin (when creating a Date object from year, month etc.):
```
if (utc) {
  return new Date(Date.UTC(Y, M, D, h, m, s, ms))
}
return new Date(Y, M, D, h, m, s, ms)
```

As the AdvancedParse plugin replaces the implementation of the parse method, this if statement would have to be duplicated to this plugin.

I refactored the code, to remove this dependency by creating a `dateFromDateComponents` method in the core module that is overwritten in the utc plugin. This way in 'standard' mode a Date with the current offset is created, while in 'utc' mode we will get an utc Date.

As an added bonus the utc plugin does not have to overwrite the parse method of the core module, potentially creating problems, when plugins are not imported in the "right" order.
