### PR TITLE
feat: add a getter for the name of the global locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "vitest",
     "test:ui": "vitest --ui --api 9527",
     "test:run": "vitest --run",
-    "test:run-browser": "vitest --run --browser.enabled",
+    "test:run-browser": "vitest --run --browser.enabled --testTimeout=20000",
     "test:coverage": "vitest run --coverage",
     "release": "commit-and-tag-version -i CHANGELOG.md --same-file",
     "lint-commits": "commitlint --from b4c0a8614dd7d9997 --to HEAD --verbose",

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -8,7 +8,6 @@ const esday: EsDayFactory = (d?: DateType, ...others: (SimpleType | { [key: stri
   if (d instanceof EsDay) {
     return d.clone()
   }
-
   else {
     const conf: SimpleObject = {}
     others.forEach((o, i) => {

--- a/src/plugins/locale/types.ts
+++ b/src/plugins/locale/types.ts
@@ -8,19 +8,26 @@ import type { EsDay } from 'esday'
  > = R['length'] extends N ? R : ReadonlyTuple<T, N, readonly [T, ...R]>
 
 declare module 'esday' {
-/*   interface EsDay {
+/* get locale object of instance
+  interface EsDay {
     $locale: () => Locale
-  } */
+  }
+*/
 
   interface EsDay {
+    /**
+     * set locale of instance
+     */
     locale: (localeName: string) => EsDay
   }
 
   interface EsDayFactory {
     /**
-     * use locale as global
+     * set / get locale globally
      */
-    locale: (localeName: string) => EsDayFactory
+    // locale<T extends string | undefined = undefined>(localeName?: T): T extends string ? EsDayFactory : string
+    locale: <T extends string | undefined = undefined>(localeName?: T) => T extends string ? EsDayFactory : string
+
     /**
      * register locale
      */

--- a/test/plugins/locale.test.ts
+++ b/test/plugins/locale.test.ts
@@ -18,6 +18,14 @@ describe('factory locale methods', () => {
     expect(getLocaleName(esday())).toBe('non-exist')
   })
 
+  it('get locale', () => {
+    esday.locale('zh')
+    expect(esday.locale()).toBe('zh')
+
+    esday.locale('non-exist')
+    expect(esday.locale()).toBe('non-exist')
+  })
+
   it('register locale', () => {
     esday.registerLocale(localeZh)
     esday.locale('zh')
@@ -33,6 +41,7 @@ describe('factory locale methods', () => {
 
 describe('esDay locale methods', () => {
   const day = esday('2021-01-01')
+
   it('set locale for instance', () => {
     expect(getLocaleName(day)).toBe('en')
     const dayZh = day.locale('zh')


### PR DESCRIPTION
Add a getter for the global locale to improve the compatibility with momentjs.

Syntax: `esday.locale()`.