### PR TITLE
feat: add getter for locale of an instance; add getter localeObject

### DIFF
--- a/src/plugins/locale/index.ts
+++ b/src/plugins/locale/index.ts
@@ -89,17 +89,21 @@ function getSetPrivateLocaleName(inst: EsDay, newLocaleName?: string): string {
 }
 
 const localePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
-  // @ts-expect-error $locale is private method
-  dayClass.prototype.$locale = function () {
+  dayClass.prototype.localeObject = function () {
     return getLocale(getSetPrivateLocaleName(this))
   }
 
-  // setter for instance locale
-  dayClass.prototype.locale = function (localeName: string) {
-    const inst = this.clone()
-    getSetPrivateLocaleName(inst, localeName)
-
-    return inst
+  // add locale getter / setter
+  dayClass.prototype.locale = function <T extends string | undefined>(localeName?: T): T extends string ? EsDay : string {
+  // dayClass.prototype.locale = function (localeName?: string): any {
+    if ((localeName !== undefined) && (typeof localeName === 'string')) {
+      const inst = this.clone()
+      getSetPrivateLocaleName(inst, localeName)
+      return inst as any
+    }
+    else {
+      return getSetPrivateLocaleName(this) as any
+    }
   }
 
   // set $l in clone method
@@ -125,8 +129,7 @@ const localePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
     if (prettyUnit(unit) === C.WEEK) {
       // default start of week is Monday
       const defaultStartOfWeek = C.INDEX_MONDAY
-      // @ts-expect-error $locale is private method
-      const weekStart = undefinedOr(inst.$locale().weekStart, defaultStartOfWeek)
+      const weekStart = undefinedOr(inst.localeObject().weekStart, defaultStartOfWeek)
       const $day = origin.day()
       const $date = origin.date()
       const diff = ($day < weekStart ? $day + 7 : $day) - weekStart

--- a/src/plugins/locale/types.ts
+++ b/src/plugins/locale/types.ts
@@ -8,24 +8,23 @@ import type { EsDay } from 'esday'
  > = R['length'] extends N ? R : ReadonlyTuple<T, N, readonly [T, ...R]>
 
 declare module 'esday' {
-/* get locale object of instance
-  interface EsDay {
-    $locale: () => Locale
-  }
-*/
-
   interface EsDay {
     /**
-     * set locale of instance
+     * overloads for getter / setter of locale of instance
+     * locale(): string
+     * locale(localeName: string): EsDay
      */
-    locale: (localeName: string) => EsDay
+    locale: <T extends string | undefined = undefined>(localeName?: T) => T extends string ? EsDay : string
+
+    localeObject: () => Locale
   }
 
   interface EsDayFactory {
     /**
-     * set / get locale globally
+     * overloads for getter / setter of locale of prototype
+     * locale(): string
+     * locale(localeName: string): EsDay
      */
-    // locale<T extends string | undefined = undefined>(localeName?: T): T extends string ? EsDayFactory : string
     locale: <T extends string | undefined = undefined>(localeName?: T) => T extends string ? EsDayFactory : string
 
     /**

--- a/src/plugins/weekOfYear/index.ts
+++ b/src/plugins/weekOfYear/index.ts
@@ -15,8 +15,8 @@ const weekOfYearPlugin: EsDayPlugin<{}> = (_, dayClass) => {
     if (week) {
       return this.add((week - this.week()) * 7, C.DAY)
     }
-    // @ts-expect-error '$locale' is a private method when plugin locale is installed
-    const yearStart = this.$locale?.().yearStart || INDEX_THURSDAY // default to Thursday according to ISO 8601
+
+    const yearStart = this.localeObject?.().yearStart || INDEX_THURSDAY // default to Thursday according to ISO 8601
     if (this.month() === 11 && this.date() > 25) {
       const nextYearStartDay = this.startOf(C.YEAR).add(1, C.YEAR).date(yearStart)
       const thisEndOfWeek = this.endOf(C.WEEK)

--- a/test/plugins/locale.test.ts
+++ b/test/plugins/locale.test.ts
@@ -29,13 +29,11 @@ describe('factory locale methods', () => {
   it('register locale', () => {
     esday.registerLocale(localeZh)
     esday.locale('zh')
-    // @ts-expect-error $locale is private method
-    expect(esday().$locale()).toBe(localeZh)
+    expect(esday().localeObject()).toBe(localeZh)
 
     esday.registerLocale(localeZh, 'zh-cn')
     esday.locale('zh-cn')
-    // @ts-expect-error $locale is private method
-    expect(esday().$locale()).toBe(localeZh)
+    expect(esday().localeObject()).toBe(localeZh)
   })
 })
 

--- a/test/plugins/weekOfYear.test.ts
+++ b/test/plugins/weekOfYear.test.ts
@@ -29,7 +29,7 @@ describe('week plugin', () => {
     const customYearStart = 1 // 2nd day of the year
     const customDay = esday('2023-01-01') // Sunday
     // @ts-expect-error Mock `$locale` method to return custom `yearStart`
-    customDay['$locale'] = () => ({ yearStart: customYearStart })
+    customDay['localeObject'] = () => ({ yearStart: customYearStart })
     expect(customDay.weeks()).toBe(1)
   })
 


### PR DESCRIPTION
Add a getter for the locale name of an instance (`esday().locale()`).
Add a getter for the locale object used by an esday object (`esday().localeObject`).

localeObject() is required by plugins that depend on the current locale of esday.