### PR TITLE
Feat: add method 'diff' to EsDay

### DIFF
--- a/docs/core/diff.md
+++ b/docs/core/diff.md
@@ -1,0 +1,54 @@
+# Difference
+
+The `diff` method calculates the difference between two esday objects using the specified unit.
+
+The default unit is milliseconds.
+
+To get the difference in another unit of measurement, pass that measurement as the second argument.
+
+By default `diff` will truncate the result to an integer. If you want a floating point number, pass true as the third argument.
+
+## Method signatures
+```
+esday().diff(date: EsDay, unit?: UnitType, asFloat?: boolean): number
+```
+| parameter | description                                         |
+| --------- | --------------------------------------------------- |
+| date      | EsDay object to calculate the difference to         |
+| unit      | Eunit to use for the calculated difference          |
+| asFloat   | return the result as float  (false= return integer) |
+
+## Available Units in UnitType
+| **Unit** | **Shorthand**                       | **Description**                                            |
+| --------- | --------------------------------- | ---------------------------------------------------------- |
+| YY        | 1                                 | Two-digit year                                             |
+| YYYY      | 2001                              | Four-digit year                                            |
+| M         | 1-12                              | Month, beginning at 1                                      |
+| MM        | 01-12                             | Month, 2-digits                                            |
+| D         | 1-31                              | Day of month                                               |
+| DD        | 01-31                             | Day of month, 2-digits                                     |
+| H         | 0-23                              | Hours                                                      |
+| HH        | 00-23                             | Hours, 2-digits                                            |
+| m         | 0-59                              | Minutes                                                    |
+| mm        | 00-59                             | Minutes, 2-digits                                          |
+| s         | 0-59                              | Seconds                                                    |
+| ss        | 00-59                             | Seconds, 2-digits                                          |
+| SSS       | 000-999                           | Milliseconds, 3-digits                                     |
+| Z         | +05:00:00                         | Offset from UTC                                            |
+
+## Examples
+```typescript
+import { esday } from 'esday'
+
+// calculating difference with default unit ('milliseconds')
+esday('2019-01-25').diff(esday(('2018-06-05'))
+// Returns 20214000000
+
+// calculating difference with unit 'months'
+esday('2019-01-25').diff(esday(('2018-06-05'), 'month')
+// Returns 7
+
+// calculating difference with unit 'months' as float
+esday('2019-01-25').diff(esday(('2018-06-05'), 'month', true)
+// Returns 7.645161290322581
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,9 @@ EsDay is a JavaScript library inspired by [Day.js](https://github.com/iamkun/day
 
 EsDay has an API largely similar to [Moment.js](https://momentjs.com/docs/) (v2.30.1) and Day.js (v1.11.13), but it is written in TypeScript and fully supports es modules. When there are differences between Moment.js and Day.js, the functionality of Moment.js is usually preferred.
 
+EsDay has many integrated functions:
+- [diff](./core/diff.md) calculating the difference between 2 esday objects based on a given unit.
+
 EsDay supports many locales. A list of the supported locales can be found in the [details page](./locales/locales.md).
 
 EsDay is extensible by plugins.

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -20,6 +20,7 @@ export const HOUR = 'hour' as const
 export const DAY = 'day' as const
 export const WEEK = 'week' as const
 export const MONTH = 'month' as const
+export const QUARTER = 'quarter' as const
 export const YEAR = 'year' as const
 export const DATE = 'date' as const
 
@@ -52,6 +53,7 @@ export default {
   DAY,
   WEEK,
   MONTH,
+  QUARTER,
   YEAR,
   DATE,
   FORMAT_DEFAULT,

--- a/src/common/date-fields.ts
+++ b/src/common/date-fields.ts
@@ -1,5 +1,5 @@
 import { isArray } from './is'
-import type { PrettyUnit, UnitDay, UnitType, UnitWeek } from './units'
+import type { PrettyUnit, UnitDay, UnitQuarter, UnitType, UnitWeek } from './units'
 import { prettyUnit } from './units'
 
 const UNIT_FIELD_MAP = {
@@ -18,27 +18,30 @@ type DateField<T extends DateUnit> = (typeof UNIT_FIELD_MAP)[T]
 
 export const prettyUnits = Object.keys(UNIT_FIELD_MAP) as (keyof typeof UNIT_FIELD_MAP)[]
 
-export function unitToField<T extends Exclude<UnitType, UnitWeek>>(
+export function unitToField<T extends Exclude<UnitType, UnitWeek | UnitQuarter>>(
   unit: T,
 ): DateField<PrettyUnit<T>> {
   const p = prettyUnit(unit)
   return UNIT_FIELD_MAP[p]
 }
 
-export function getUnitInDate(date: Date, unit: Exclude<UnitType, UnitWeek>): number {
+export function getUnitInDate(date: Date, unit: Exclude<UnitType, UnitWeek | UnitQuarter>): number {
   const field = unitToField(unit)
   const method = `get${field}` as `get${typeof field}`
   return date[method]()
 }
 
-export function getUnitInDateUTC(date: Date, unit: Exclude<UnitType, UnitWeek>): number {
+export function getUnitInDateUTC(
+  date: Date,
+  unit: Exclude<UnitType, UnitWeek | UnitQuarter>,
+): number {
   const field = unitToField(unit)
   return date[`getUTC${field}` as `getUTC${typeof field}`]()
 }
 
 export function setUnitInDate(
   date: Date,
-  unit: Exclude<UnitType, UnitWeek | UnitDay>,
+  unit: Exclude<UnitType, UnitDay | UnitWeek | UnitQuarter>,
   value: number | number[],
 ): Date {
   const field = unitToField(unit)
@@ -49,7 +52,7 @@ export function setUnitInDate(
 
 export function setUnitInDateUTC(
   date: Date,
-  unit: Exclude<UnitType, UnitWeek | UnitDay>,
+  unit: Exclude<UnitType, UnitDay | UnitWeek | UnitQuarter>,
   value: number | number[],
 ): Date {
   const field = unitToField(unit)

--- a/src/common/units.ts
+++ b/src/common/units.ts
@@ -1,15 +1,16 @@
-import { DATE, DAY, HOUR, MIN, MONTH, MS, SECOND, WEEK, YEAR } from './constants'
+import { DATE, DAY, HOUR, MIN, MONTH, MS, QUARTER, SECOND, WEEK, YEAR } from './constants'
 
 const UNIT_MAP = {
   y: YEAR,
+  Q: QUARTER,
   M: MONTH,
+  w: WEEK,
   D: DATE,
   d: DAY,
   h: HOUR,
   m: MIN,
   s: SECOND,
   ms: MS,
-  w: WEEK,
 } as const
 
 export type ShortUnit = keyof typeof UNIT_MAP
@@ -18,14 +19,15 @@ export type UnitType = ShortUnit | PrettyUnitType
 export type PrettyUnit<T extends UnitType> = T extends ShortUnit ? (typeof UNIT_MAP)[T] : T
 type UnionUnit<T extends ShortUnit> = T | PrettyUnit<T>
 export type UnitYear = UnionUnit<'y'>
+export type UnitQuarter = UnionUnit<'Q'>
 export type UnitMonth = UnionUnit<'M'>
+export type UnitWeek = UnionUnit<'w'>
 export type UnitDate = UnionUnit<'D'>
 export type UnitDay = UnionUnit<'d'>
 export type UnitHour = UnionUnit<'h'>
 export type UnitMin = UnionUnit<'m'>
 export type UnitSecond = UnionUnit<'s'>
 export type UnitMs = UnionUnit<'ms'>
-export type UnitWeek = UnionUnit<'w'>
 
 export function prettyUnit<T extends UnitType>(u: T): PrettyUnit<T> {
   const maybePrettyUnit = UNIT_MAP[u as ShortUnit]

--- a/src/core/EsDay.ts
+++ b/src/core/EsDay.ts
@@ -17,6 +17,7 @@ import type { DateType, UnitType } from '~/types'
 import type { SimpleObject } from '~/types/util-types'
 import { esday } from '.'
 import { addImpl } from './Impl/add'
+import { diffImpl } from './Impl/diff'
 import { formatImpl } from './Impl/format'
 import { parseArrayToDate } from './Impl/parse'
 import { startOfImpl } from './Impl/startOf'
@@ -233,6 +234,10 @@ export class EsDay {
 
   subtract(number: number, units: UnitType) {
     return this.add(-number, units)
+  }
+
+  diff(date: EsDay, units?: UnitType, asFloat = false): number {
+    return diffImpl(this, date, units, asFloat)
   }
 
   get(units: Exclude<UnitType, UnitWeek | UnitQuarter>) {

--- a/src/core/EsDay.ts
+++ b/src/core/EsDay.ts
@@ -6,6 +6,7 @@ import type {
   UnitMin,
   UnitMonth,
   UnitMs,
+  UnitQuarter,
   UnitSecond,
   UnitWeek,
   UnitYear,
@@ -234,7 +235,7 @@ export class EsDay {
     return this.add(-number, units)
   }
 
-  get(units: Exclude<UnitType, UnitWeek>) {
+  get(units: Exclude<UnitType, UnitWeek | UnitQuarter>) {
     return getUnitInDate(this.$d, units)
   }
 
@@ -246,7 +247,7 @@ export class EsDay {
   set(unit: UnitMin, min: number, sec?: number, ms?: number): EsDay
   set(unit: UnitSecond, sec: number, ms?: number): EsDay
   set(unit: UnitMs, ms: number): EsDay
-  set(unit: Exclude<UnitType, UnitWeek>, ...values: number[]) {
+  set(unit: Exclude<UnitType, UnitWeek | UnitQuarter>, ...values: number[]) {
     return this.clone().$set(unit, values)
   }
 
@@ -270,7 +271,7 @@ export class EsDay {
     return this.$d.toUTCString()
   }
 
-  private $set(unit: Exclude<UnitType, UnitWeek>, values: number[]) {
+  private $set(unit: Exclude<UnitType, UnitWeek | UnitQuarter>, values: number[]) {
     if (prettyUnit(unit) === C.DAY) {
       setUnitInDate(this.$d, C.DATE, this.date() + (values[0] - this.day()))
     } else {

--- a/src/core/Impl/diff.ts
+++ b/src/core/Impl/diff.ts
@@ -1,0 +1,90 @@
+import { C, isUndefined, prettyUnit } from '~/common'
+import type { EsDay } from '~/core'
+import type { UnitType } from '~/types'
+
+/**
+ * get difference between 2 dates as months
+ * @param a - date 1
+ * @param b - date 2
+ * @returns b - a in months
+ */
+function monthDiff(a: EsDay, b: EsDay): number {
+  // function from moment.js in order to keep the same result
+  if (a.date() < b.date()) return -monthDiff(b, a)
+  const wholeMonthDiff = (b.year() - a.year()) * 12 + (b.month() - a.month())
+  const anchor: EsDay = a.clone().add(wholeMonthDiff, C.MONTH)
+  const c = b.valueOf() - anchor.valueOf() < 0
+  const anchor2 = a.clone().add(wholeMonthDiff + (c ? -1 : 1), C.MONTH)
+  return +(
+    -(
+      wholeMonthDiff +
+      (b.valueOf() - anchor.valueOf()) /
+        (c ? anchor.valueOf() - anchor2.valueOf() : anchor2.valueOf() - anchor.valueOf())
+    ) || 0
+  )
+}
+
+/**
+ * Drop fractional part of a number.
+ * @param n - number to inspect
+ * @returns n without fractional part
+ */
+function absFloor(n: number): number {
+  return n < 0 ? Math.ceil(n) || 0 : Math.floor(n)
+}
+
+/**
+ * Get the utcOffset of date.
+ * Use the utcOffset method from the utc plugin if that is loaded;
+ * otherwise get it from the javascript Date object of date.
+ * @param date - EsDay instance to inspect
+ * @returns utcOffset of date
+ */
+function utcOffset(date: EsDay): number {
+  const defaultOffset = -Math.round(date['$d'].getTimezoneOffset()) || 0
+  return 'utcOffset' in date ? date.utcOffset() : defaultOffset
+}
+
+export function diffImpl(that: EsDay, date: EsDay, units?: UnitType, asFloat = false): number {
+  const diffInMs = that.valueOf() - date.valueOf()
+  const diffInMonths = monthDiff(that, date)
+  const zoneDelta = (utcOffset(that) - utcOffset(date)) * C.MILLISECONDS_A_MINUTE
+  let result: number
+
+  if (!isUndefined(units)) {
+    const unit = prettyUnit(units)
+    switch (unit) {
+      case C.YEAR:
+        result = diffInMonths / 12
+        break
+      case C.MONTH:
+        result = diffInMonths
+        break
+      case C.QUARTER:
+        result = diffInMonths / 3
+        break
+      case C.WEEK:
+        result = (diffInMs - zoneDelta) / C.MILLISECONDS_A_WEEK
+        break
+      case C.DAY:
+        result = (diffInMs - zoneDelta) / C.MILLISECONDS_A_DAY
+        break
+      case C.HOUR:
+        result = diffInMs / C.MILLISECONDS_A_HOUR
+        break
+      case C.MIN:
+        result = diffInMs / C.MILLISECONDS_A_MINUTE
+        break
+      case C.SECOND:
+        result = diffInMs / C.MILLISECONDS_A_SECOND
+        break
+      default:
+        result = diffInMs // milliseconds
+        break
+    }
+  } else {
+    result = diffInMs // milliseconds
+  }
+
+  return asFloat ? result : absFloor(result)
+}

--- a/src/core/Impl/diff.ts
+++ b/src/core/Impl/diff.ts
@@ -9,11 +9,15 @@ import type { UnitType } from '~/types'
  * @returns b - a in months
  */
 function monthDiff(a: EsDay, b: EsDay): number {
-  // function from moment.js in order to keep the same result
+  // taken from moment.js for compatibility
   if (a.date() < b.date()) return -monthDiff(b, a)
   const wholeMonthDiff = (b.year() - a.year()) * 12 + (b.month() - a.month())
   const anchor: EsDay = a.clone().add(wholeMonthDiff, C.MONTH)
+
+  // is wholeMonthDiff too large?
   const c = b.valueOf() - anchor.valueOf() < 0
+
+  // if so then subtract 1 month else add 1 month
   const anchor2 = a.clone().add(wholeMonthDiff + (c ? -1 : 1), C.MONTH)
   return +(
     -(

--- a/src/core/Impl/startOf.ts
+++ b/src/core/Impl/startOf.ts
@@ -1,5 +1,5 @@
 import type { EsDay } from 'esday'
-import type { UnitWeek } from '~/common'
+import type { UnitQuarter, UnitWeek } from '~/common'
 import { C, prettyUnit } from '~/common'
 import type { UnitType } from '~/types'
 
@@ -10,7 +10,7 @@ export function startOfImpl(that: EsDay, unit: UnitType, reverse = false) {
   // eslint-disable-next-line dot-notation
   const setterFunc = result['$set']
 
-  const instanceFactorySet = (method: Exclude<UnitType, UnitWeek>, slice: number) => {
+  const instanceFactorySet = (method: Exclude<UnitType, UnitWeek | UnitQuarter>, slice: number) => {
     const argumentStart = [0, 0, 0, 0]
     const argumentEnd = [23, 59, 59, 999]
     const argument = reverse ? argumentEnd.slice(slice) : argumentStart.slice(slice)

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -1,0 +1,266 @@
+import { esday } from 'esday'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { C } from '~/common'
+import { expectSame } from './util'
+
+describe('Difference', () => {
+  const fakeTimeAsString = '2025-03-17T03:24:46.234'
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(fakeTimeAsString))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it.each([{ sourceString: '20240101' }, { sourceString: '2023-02-08' }])(
+    'diff for "$sourceString"with default parameters (returns milliseconds)',
+    ({ sourceString }) => {
+      expectSame((esday) => esday().diff(esday(sourceString)))
+    },
+  )
+
+  it.each([
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.MS,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.SECOND,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.MIN,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.HOUR,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.DAY,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.WEEK,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.MONTH,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.QUARTER,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.YEAR,
+    },
+  ])(
+    'diff for B > A in unit "$unit"',
+    ({ sourceString, sourceDiffValue, sourceDiffUnit, resultUnit }) => {
+      expectSame((esday) =>
+        esday(sourceString).diff(
+          esday(sourceString).add(sourceDiffValue, sourceDiffUnit),
+          resultUnit,
+        ),
+      )
+    },
+  )
+
+  it.each([
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.MS,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.SECOND,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.MIN,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.HOUR,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.DAY,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.WEEK,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.MONTH,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.QUARTER,
+    },
+    {
+      sourceString: '2013-02-08T13:24:35.789',
+      sourceDiffValue: 1000,
+      sourceDiffUnit: C.DAY,
+      resultUnit: C.YEAR,
+    },
+  ])(
+    'diff for B < A in unit "$unit"',
+    ({ sourceString, sourceDiffValue, sourceDiffUnit, resultUnit }) => {
+      expectSame((esday) =>
+        esday(sourceString).diff(
+          esday(sourceString).subtract(sourceDiffValue, sourceDiffUnit),
+          resultUnit,
+        ),
+      )
+    },
+  )
+
+  it.each([
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2013-02-08T13:24:35.789',
+      resultUnit: C.MS,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2013-02-08T13:24:35.789',
+      resultUnit: C.SECOND,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2013-02-08T13:24:35.789',
+      resultUnit: C.MIN,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2013-02-08T13:24:35.789',
+      resultUnit: C.HOUR,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2013-02-08T13:24:35.789',
+      resultUnit: C.DAY,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2013-02-08T13:24:35.789',
+      resultUnit: C.WEEK,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2013-02-08T13:24:35.789',
+      resultUnit: C.MONTH,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2013-02-08T13:24:35.789',
+      resultUnit: C.QUARTER,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2013-02-08T13:24:35.789',
+      resultUnit: C.YEAR,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2014-01-08T13:24:35.789',
+      resultUnit: C.MS,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2014-01-08T13:24:35.789',
+      resultUnit: C.SECOND,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2014-01-08T13:24:35.789',
+      resultUnit: C.MIN,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2014-01-08T13:24:35.789',
+      resultUnit: C.HOUR,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2014-01-08T13:24:35.789',
+      resultUnit: C.DAY,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2014-01-08T13:24:35.789',
+      resultUnit: C.WEEK,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2014-01-08T13:24:35.789',
+      resultUnit: C.MONTH,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2014-01-08T13:24:35.789',
+      resultUnit: C.QUARTER,
+    },
+    {
+      sourceString1: '2013-02-08T13:24:35.789',
+      sourceString2: '2014-01-08T13:24:35.789',
+      resultUnit: C.YEAR,
+    },
+  ])('diff in unit "$unit" as float', ({ sourceString1, sourceString2, resultUnit }) => {
+    expectSame((esday) => esday(sourceString1).diff(esday(sourceString2), resultUnit, true))
+  })
+
+  it.each([
+    { sourceString1: '2024-08-08', sourceString2: '2024-08-08', expected: 0 },
+    { sourceString1: '2024-09-08', sourceString2: '2024-08-08', expected: 1 },
+    { sourceString1: '2024-08-08', sourceString2: '2024-09-08', expected: -1 },
+    { sourceString1: '2024-01-01', sourceString2: '2024-01-01', expected: 0 },
+  ])(
+    'diff in "months" between "$sourceString1" and "$sourceString2" - testing internal  monthDiff function',
+    ({ sourceString1, sourceString2, expected }) => {
+      expectSame((esday) => esday(sourceString1).diff(esday(sourceString2), C.MONTH))
+      expect(esday(sourceString1).diff(esday(sourceString2), 'month')).toBe(expected)
+    },
+  )
+})


### PR DESCRIPTION
Add method 'diff' to EsDay to calculate the difference between 2 dates based on the given units. This method is required e.g. to fix the errors in the WeekOfÝear plugin.