### PR TITLE
Docs: add docs for WeekYear and WeekOfYear plugin and extend docs for Locale plugin

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,14 @@ EsDay is a JavaScript library inspired by [Day.js](https://github.com/iamkun/day
 
 EsDay has an API largely similar to [Moment.js](https://momentjs.com/docs/) (v2.30.1) and Day.js (v1.11.13), but it is written in TypeScript and fully supports es modules. When there are differences between Moment.js and Day.js, the functionality of Moment.js is usually preferred.
 
+## Core functions
 EsDay has many integrated functions:
 - [diff](./core/diff.md) calculating the difference between 2 esday objects based on a given unit.
 
+## Locales
 EsDay supports many locales. A list of the supported locales can be found in the [details page](./locales/locales.md).
 
+## Plugins
 EsDay is extensible by plugins.
 
 Currently there are the following plugins:
@@ -18,10 +21,23 @@ Currently there are the following plugins:
 - IsSameOrAfter (IsSameOrAfter adds .isSameOrAfter() API - is date the same or after another date)
 - IsSameOrBefore (IsSameOrBefore adds .isSameOrBefore() API - is date the same or before another date)
 - IsToday (IsToday adds .isToday() API is date today)
-- Locale (add locale functions to EsDay)
+- [Locale](./plugins/locale.md) (add locale functions to EsDay)
 - MinMax (MinMax adds .min() and .max() APIs - find the minimum or maximum of several dates)
 - ToArray (ToArray adds .toArray() API - get an array with the components of a date)
 - ToObject (ToObject adds .toObject() API - get an object with the components of a date)
 - Utc (UTC adds .utc(), .local() and .isUTC APIs - handle dates as UTC)
-- WeekOfYear (WeekOfYear adds .week() API - get the week of the year of a date)
-- WeekYear (WeekYear adds .weekYear() API - get locale aware week of the year of a date)
+- [WeekOfYear](./plugins/weekOfYear.md) (WeekOfYear adds .week() API - get the week of the year of a date)
+- [WeekYear](./plugins/weekYear.md) (WeekYear adds .weekYear() API - get locale aware week-year of a date)
+
+## Differences to Day.js
+
+- **Locale**: Locale  is a Plugin; no default locale! Dayjs uses 'en-US' as default.
+- **'Start of Week'**: Default 'Start of Week' is 1 ('Monday') as defined by ISO 8601. Dayjs uses 0 ('Sunday') as (as defined by the dafault locale 'en-US').
+- **'Start of Year'**: Default 'Start of Year' is 4 (Jan 4th must be in the 1st week of the year) as defined by ISO 8601. Dayjs uses 1 (Jan 1st) as (as defined by the dafault locale 'en-US').
+
+## Differences to Moment.js
+
+Esday uses moment@2.30.1 as api reference.
+
+- **toString**: conforms to Day.js and uses Date.toUTCString() (returning the date in RFC 7231 format 'ddd, DD MMM YYYY HH:mm:ss [GMT]') while moment uses the format 'ddd MMM DD YYYY HH:mm:ss [GMT]ZZ'.
+- **toISOString**: conforms to Day.js and returns 'Invalid Date' when called on an invalid date. In that case moment returns null (see [moment pr#3710](https://github.com/moment/moment/pull/3710)).

--- a/docs/plugins/locale.md
+++ b/docs/plugins/locale.md
@@ -7,26 +7,48 @@ For esday (`esday`)
 ```
 // get / set name of global locale
 locale(): string
-locale(localeName: string): EsDayFactory
+locale(localeName: string): EsDay
 
 // add a locale to the list of available locales
-registerLocale(locale: Locale, newName?: string): EsDayFactory
+registerLocale(locale: Locale, newName?: string): EsDay
 
 // get the locale object from the name of the locale
-getLocale(name: string): Locale
+localeObject(name: string): Locale
 ```
 
 For esday instance (`esday()`)
 ```
-// set the locale of an esday object
+// get / set the locale of an esday instance
+locale(): string
 locale(name: string): EsDay
 ```
 
-| parameter | description                              |
-| --------- | ---------------------------------------- |
-| locale    | locale object to use                     |
+| Parameter | Type   | Description          |
+| --------- | ------ | ---------------------|
+| locale    | Locale | locale object to use |
 
-# Examples
+## Locale object
+
+Properties of the `Locale` object:
+
+| Property      | Type     | Description                                                                                                                |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------|
+| name          | string   | Name of the locale (e.g. `en-US`)                                                                                          |
+| weekdays      | DayNames | Array of the full day names (e.g. `['Sunday', 'Monday', ... ]`)                                                            |
+| weekdaysShort | DayNames | Array of the short day names (e.g. `['Sun', 'Mon', ... ]`)                                                                 |
+| weekdaysMin   | DayNames | Array of the short day names (e.g. `['Su', 'Mo', ... ]`)                                                                   |
+| months        | MonthNames \| MonthNamesStandaloneFormat \| MonthNamesFunction | Array of the full month names (e.g. `['January', 'February', ... ]`) |
+| monthsShort   | MonthNames \| MonthNamesStandaloneFormat \| MonthNamesFunction | Array of the short month names (e.g. `['Jan', 'Feb', ... ]`)         |
+| ordinal       | function | Get the ordinal form of a number (e.g. `ordinal(1) // returns '1st'`)                                                      |
+| weekStart     | number   | Which is the 1st day of the week - 0=Sunday, 1=Monday etc. (e.g. `1` for Monday)                                           |
+| yearStart     | number   | Which date **must** be part of the 1st week of the year (e.g. `4` for Jan 4th)                                             |
+| formats       | object   | Localized format tokens for parsing and formatting (e.g. `LT` or `LL`)                                                     |
+| relativeTime  | <Relative, string | RelativeTimeElementFunction>[] \| Replacement strings for relative time values (e.g. `future: 'in %s'`)           |
+| meridiem      | function | Get meridiem string for a time value (e.g. `pm`)                                                                           |
+
+All properties are readonly.
+
+## Examples
 
 ```typescript
 import { esday } from 'esday'

--- a/docs/plugins/weekOfYear.md
+++ b/docs/plugins/weekOfYear.md
@@ -1,0 +1,38 @@
+# WeekOfYear
+
+WeekOfYear adds the `week` and the  the `weeks` methods to EsDay to get or set the week of the year of a date according to the active locale. The `weeks` method is just an alias for the `week` method.
+
+The week of the year varies depending on which day is the first day of the week (Sunday, Monday, etc), and with which day (of the month) the first week of the year starts.
+
+For example, in the US, Sunday is the first day of the week. The week with January 1st in it is the first week of the year.
+
+In France, Monday is the first day of the week, and the week with January 4th is the first week of the year.
+
+When setting the week of the year, the day of the week is retained.
+
+## Method signatures
+```typescript
+esday().week(): number
+esday().week(week: number): EsDay
+esday().weeks(): number
+esday().weeks(week: number): EsDay
+```
+
+## Examples
+```typescript
+import { esday } from 'esday'
+import weekYearOfPlugin from 'esday/plugins/weekOfYear'
+import localeEn from 'esday/locales/en'
+import localePlugin from 'esday/plugins/locale'
+
+esday.extend(localePlugin)
+esday.extend(weekOfYearPlugin)
+
+esday.registerLocale(localeEn)
+
+esday('2024-01-01')weekOfYear()
+// Returns 1
+
+esday('2024-02-14')weekYear(1)
+// Returns esday for '2024-01-03'
+```

--- a/docs/plugins/weekYear.md
+++ b/docs/plugins/weekYear.md
@@ -1,0 +1,37 @@
+# WeekYear
+
+WeekYear adds the `weekYear` method to EsDay to get the week-year of a date.
+
+Because the first day of the first week of a year does not always fall on the first day of the year, sometimes the week-year will differ from the month year.
+
+For example, in the US, the week that contains Jan 1st is always the first week. In the US, weeks also start on Sunday.
+If Jan 1 was a Monday, Dec 31 would belong to the same week as Jan 1, and thus the same week-year as Jan 1 (e.g. 2024).
+Dec 30 would have a different week-year than Dec 31 (in the previous case it would be 2023).
+
+## Dependencies
+
+The `WeekYear` plugin requires the plugin `WeekOfYear`. This plugin must be activated before the plugin WeekYear.
+
+## Method signatures
+```typescript
+esday().weekYear(): number
+```
+
+## Examples
+```typescript
+import { esday } from 'esday'
+import weekOfYearPlugin from 'esday/plugins/weekOfYear'
+import weekYearPlugin from 'esday/plugins/weekYear'
+
+esday.extend(weekOfYearPlugin)
+esday.extend(weekYearPlugin)
+
+esday('2023-12-30')weekYear()
+// Returns 2023
+
+esday('2023-12-31')weekYear()
+// Returns 2024
+
+esday('2024-01-01')weekYear()
+// Returns 2024
+```


### PR DESCRIPTION
Add more documentation pages (WeekYear and WeekOfYear plugin).
Extend documentation for Locale plugin (description of properties).