### PR TITLE
Feat: add plugin AdvancedFormat - solves issue #54

### DIFF
--- a/docs/core/format.md
+++ b/docs/core/format.md
@@ -1,0 +1,41 @@
+# Formatting
+
+The `esday().format()` function returns a string representing an `esday` object.
+
+## Method signatures
+```
+esday().format(formatTemplate?: string): string
+```
+| parameter      | description                                   |
+| -------------- | --------------------------------------------- |
+| formatTemplate | template used for formatting the EsDay object |
+
+## Parsing tokens
+| **Token** | **Example**                       | **Description**                                            |
+| --------- | --------------------------------- | ---------------------------------------------------------- |
+| YY        | 1                                 | Two-digit year                                             |
+| YYYY      | 2001                              | Four-digit year                                            |
+| M         | 1-12                              | Month, beginning at 1                                      |
+| MM        | 01-12                             | Month, 2-digits                                            |
+| D         | 1-31                              | Day of month                                               |
+| DD        | 01-31                             | Day of month, 2-digits                                     |
+| H         | 0-23                              | Hours                                                      |
+| HH        | 00-23                             | Hours, 2-digits                                            |
+| m         | 0-59                              | Minutes                                                    |
+| mm        | 00-59                             | Minutes, 2-digits                                          |
+| s         | 0-59                              | Seconds                                                    |
+| ss        | 00-59                             | Seconds, 2-digits                                          |
+| SSS       | 000-999                           | Milliseconds, 3-digits                                     |
+| Z         | +05:00:00                         | Offset from UTC                                            |
+
+To use one of the supported tokens as test between the date elements, these characters must be escaped (i.e.wrapped in square brackets).
+An example for a formatting string with escaped test is `YYY-MM-DD [MM] HH [any other text] mm [m]b`.
+
+## Examples
+### Formatting
+```typescript
+import { esday } from 'esday'
+
+esday('08-2023-14 21:43:12.123').format('MM-YYYY-DD HH:mm:ss.SSS')
+// Returns '2023-08-14T21:43:12.123'
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ EsDay has an API largely similar to [Moment.js](https://momentjs.com/docs/) (v2.
 
 EsDay has many integrated functions:
 - [diff](./core/diff.md) calculating the difference between 2 esday objects based on a given unit.
+- [formatting](./core/format.md) an esday object as a string
 
 EsDay supports many locales. A list of the supported locales can be found in the [details page](./locales/locales.md).
 
@@ -13,6 +14,7 @@ EsDay is extensible by plugins.
 
 Currently there are the following plugins:
 - [AdvancedParse](./plugins/advancedParse.md) (for parsing arbitrary formatted date and time strings)
+- [AdvancedFormat](./plugins/advancedFormat.md) (for formatting using a custom template)
 - IsBetween (IsBetween adds .isBetween() API - is date is between two other dates)
 - IsLeapYear (IsLeapYear adds .isLeapYear() API - is year a leap year)
 - IsSameOrAfter (IsSameOrAfter adds .isSameOrAfter() API - is date the same or after another date)

--- a/docs/plugins/advancedFormat.md
+++ b/docs/plugins/advancedFormat.md
@@ -1,0 +1,90 @@
+# AdvancedFormat
+
+AdvancedFormat extends `esday` to support a custom formatting template.
+
+## Method signatures
+### formatting using a given format template:
+```
+esday().format(formatTemplate: string): string
+```
+
+| parameter      | description                                   |
+| -------------- | --------------------------------------------- |
+| formatTemplate | template used for formatting the EsDay object |
+
+### Adding new formatting tokens:
+```
+esday.addTokenDefinitions(newTokens: TokenDefinitions)
+```
+
+**Format of TokenDefinitions**
+```typescript
+type TokenDefinitions = Record<string, [RegExp, RegExp, (this: ParsedElements, input: string) => void]>
+```
+
+| parameter          | type     | description                                      |
+| ------------------ | -------- | ------------------------------------------------ |
+| token              | string   | token to be parsed (e.g. 'Q')                    |
+| regex default mode | RegExp   | regex used for parsing in default mode           |
+| regex strict mode  | RegExp   | regex used for parsing in strict mode            |
+| setter             | function | function to add parsed value to result in 'this' |
+
+**Parameters of setter**
+| parameter | type           | description                   |
+| --------- | -------------- | ----------------------------- |
+| this      | ParsedElements | object for results of parsing |
+| input     | string         | parsed value                  |
+
+**Format of ParsedElements**
+```typescript
+interface ParsedElements {
+  year?: number
+  month?: number
+  day?: number
+  hours?: number
+  minutes?: number
+  seconds?: number
+  milliseconds?: number
+  zoneOffset?: number
+  unix?: number
+}
+```
+
+## Parsing tokens
+| **Token** | **Example**   | **Description**                    |
+| --------- | --------------| ---------------------------------- |
+| d         | 0-6           | Day of the week, with Sunday as 0  |
+| S         | 0-9           | Hundreds of milliseconds, 1-digit  |
+| SS        | 00-99         | Tens of milliseconds, 2-digits     |
+| ZZ        | \-0500        | Compact offset from UTC, 2-digits  |
+| X         | 1410715640579 | Unix timestamp                     |
+| x         | 1410715640579 | Unix ms timestamp                  |
+| k         | 1-24          | Hour with 0 -> 24                  |
+| kk        | 01-24         | Hour, 2-digits, with 0 -> 24       |
+
+## Examples
+### Formatting
+```typescript
+import { esday } from 'esday'
+import advancedFormatPlugin from 'esday/plugins/advancedParse'
+
+esday.extend(advancedFormatPlugin)
+
+esday('08-2023-14 21:43:12.123').format('MM-YYYY-DD HH:mm:ss.SSS')
+// Returns '2023-08-14T21:43:12.123'
+```
+
+### Adding new formatting tokens
+This functionality is above all for plugin developers
+```typescript
+const additionalTokens: TokenDefinitions = {
+  PP: [/\d\d?/, /\d{2}/, function (input) {
+    // in this example we don't use the parsed value ('input')
+    this.milliseconds = 987
+  }],
+}
+esday.addTokenDefinitions(additionalTokens)
+
+esday('2024 3').format('YYYY PP')
+// Returns '2023-08-14T21:43:12.123'
+```

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -32,8 +32,6 @@ export const INVALID_DATE_STRING = 'Invalid Date'
 // regex
 export const REGEX_PARSE_DEFAULT =
   /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[T\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/i
-export const REGEX_FORMAT =
-  /\[([^\]]+)\]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g
 
 export default {
   SECONDS_A_MINUTE,
@@ -60,5 +58,4 @@ export default {
   INVALID_DATE,
   INVALID_DATE_STRING,
   REGEX_PARSE_DEFAULT,
-  REGEX_FORMAT,
 }

--- a/src/common/str-utils.ts
+++ b/src/common/str-utils.ts
@@ -52,6 +52,13 @@ export function padNumberWithLeadingZeros(origin: number, length: number) {
   return `${dash}${result.padStart(length, '0')}`
 }
 
+/**
+ * Format utcOffset as a string with format 'hh:mm':
+ * hh: hours of the utcOffset
+ * mm: minutes of the utcOffset
+ * @param utcOffset - utcOffset to convert to a string
+ * @returns utcOffset formatted as a string
+ */
 export function padZoneStr(utcOffset: number) {
   const negMinutes = -utcOffset
   const minutes = Math.abs(negMinutes)

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -2,6 +2,7 @@ import { isArray, isObject } from '~/common'
 import type { DateType, EsDayFactory } from '~/types'
 import type { SimpleObject, SimpleType } from '~/types/util-types'
 import { EsDay } from './EsDay'
+import { addFormatTokenDefinitions } from './Impl/format'
 
 // @ts-ignore plugin declare may cause ts-type-checke error, but it's ok
 const esday: EsDayFactory = (
@@ -25,6 +26,8 @@ const esday: EsDayFactory = (
   })
   return new EsDay(d, conf)
 }
+
+esday.addFormatTokenDefinitions = addFormatTokenDefinitions
 
 esday.extend = (plugin, option) => {
   // @ts-expect-error plugin

--- a/src/plugins/advancedFormat/index.ts
+++ b/src/plugins/advancedFormat/index.ts
@@ -1,0 +1,35 @@
+import type { EsDay, EsDayFactory, EsDayPlugin, FormattingTokenDefinitions } from 'esday'
+import { padStart, padZoneStr } from '~/common'
+
+/**
+ * Get the utcOffset of date.
+ * Use the utcOffset method from the utc plugin if that is loaded;
+ * otherwise get it from the javascript Date object of date.
+ * @param date - EsDay instance to inspect
+ * @returns utcOffset of date
+ */
+function utcOffset(date: EsDay): number {
+  const defaultOffset = -Math.round(date['$d'].getTimezoneOffset()) || 0
+  return 'utcOffset' in date ? date.utcOffset() : defaultOffset
+}
+
+const advancedFormatPlugin: EsDayPlugin<{}> = (
+  _,
+  _dayClass: typeof EsDay,
+  dayFactory: EsDayFactory,
+) => {
+  // Extend formatting tokens
+  const additionalTokens: FormattingTokenDefinitions = {
+    d: (sourceDate: EsDay) => sourceDate.day().toString(),
+    S: (sourceDate: EsDay) => padStart(sourceDate.millisecond(), 3, '0').slice(0, 1),
+    SS: (sourceDate: EsDay) => padStart(sourceDate.millisecond(), 3, '0').slice(0, 2),
+    ZZ: (sourceDate: EsDay) => padZoneStr(utcOffset(sourceDate)).replace(':', ''),
+    X: (sourceDate: EsDay) => sourceDate.unix().toString(),
+    x: (sourceDate: EsDay) => sourceDate.valueOf().toString(),
+    k: (sourceDate: EsDay) => (sourceDate.hour() !== 0 ? sourceDate.hour() : 24).toString(),
+    kk: (sourceDate: EsDay) => padStart(sourceDate.hour() !== 0 ? sourceDate.hour() : 24, 2, '0'),
+  }
+  dayFactory.addFormatTokenDefinitions(additionalTokens)
+}
+
+export default advancedFormatPlugin

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,4 +1,4 @@
-import customParseFormatPlugin from './advancedParse'
+import advancedFormatPlugin from './advancedFormat'
 import isBetweenPlugin from './isBetween'
 import isSameOrAfterPlugin from './isSameOrAfter'
 import isSameOrBeforePlugin from './isSameOrBefore'
@@ -12,7 +12,7 @@ import weekOfYearPlugin from './weekOfYear'
 import weekYearPlugin from './weekYear'
 
 export {
-  customParseFormatPlugin,
+  advancedFormatPlugin,
   isBetweenPlugin,
   isSameOrAfterPlugin,
   isSameOrBeforePlugin,

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -8,6 +8,7 @@ export type EsDayFactoryParserFn = (
 export interface EsDayFactory {
   (...args: Parameters<EsDayFactoryParserFn>): ReturnType<EsDayFactoryParserFn>
   extend: <T extends {}>(plugin: EsDayPlugin<T>, option?: T) => EsDayFactory
+  addFormatTokenDefinitions: (newTokens: FormattingTokenDefinitions) => void
 }
 export type EsDayPlugin<T extends {} = {}> = (
   option: T,
@@ -27,3 +28,6 @@ export type DateFromDateComponents = (
   ms: number | undefined,
   offsetMs?: number,
 ) => Date
+
+// Types for for formatting
+export type FormattingTokenDefinitions = Record<string, (sourceDate: EsDay) => string>

--- a/test/conversion.test.ts
+++ b/test/conversion.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { esday } from '~/core'
+
+describe('conversion', () => {
+  const fakeTimeAsString = '2023-12-17T03:24:46.234Z'
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(fakeTimeAsString))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('to unix timestamp (milliseconds)', () => {
+    expect(esday().valueOf()).toBe(1702783486234)
+  })
+
+  it('to unix timestamp (seconds)', () => {
+    expect(esday().unix()).toBe(1702783486)
+  })
+
+  it('toDate', () => {
+    const base = esday()
+    const jsDate = base.toDate()
+
+    expect(jsDate).toEqual(new Date())
+    expect(jsDate.toUTCString()).toBe(base.toString())
+
+    jsDate.setFullYear(1970)
+    expect(jsDate.toUTCString()).not.toBe(base.toString())
+  })
+
+  it('toJSON with valid date creates ISO8601 format', () => {
+    expect(esday().toJSON()).toBe(fakeTimeAsString)
+  })
+
+  it('toJSON with invalid date', () => {
+    expect(esday('otherString').toJSON()).toBe(null)
+  })
+
+  it('toISOString', () => {
+    expect(esday().toISOString()).toBe(fakeTimeAsString)
+  })
+})

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -78,7 +78,7 @@ describe('Difference', () => {
       resultUnit: C.YEAR,
     },
   ])(
-    'diff for B > A in unit "$unit"',
+    'diff for B > A in unit "$resultUnit"',
     ({ sourceString, sourceDiffValue, sourceDiffUnit, resultUnit }) => {
       expectSame((esday) =>
         esday(sourceString).diff(
@@ -145,7 +145,7 @@ describe('Difference', () => {
       resultUnit: C.YEAR,
     },
   ])(
-    'diff for B < A in unit "$unit"',
+    'diff for B < A in unit "$resultUnit"',
     ({ sourceString, sourceDiffValue, sourceDiffUnit, resultUnit }) => {
       expectSame((esday) =>
         esday(sourceString).diff(
@@ -247,7 +247,7 @@ describe('Difference', () => {
       sourceString2: '2014-01-08T13:24:35.789',
       resultUnit: C.YEAR,
     },
-  ])('diff in unit "$unit" as float', ({ sourceString1, sourceString2, resultUnit }) => {
+  ])('diff in unit "$resultUnit" as float', ({ sourceString1, sourceString2, resultUnit }) => {
     expectSame((esday) => esday(sourceString1).diff(esday(sourceString2), resultUnit, true))
   })
 

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -62,15 +62,6 @@ describe('format', () => {
     expect(esday().format(formatString)).toBe(expected)
   })
 
-  it.each([{ formatString: 'd', expected: '4' }])(
-    'day of week (sun - sat) as "%s"',
-    ({ formatString, expected }) => {
-      vi.setSystemTime(new Date('2023-12-07T03:24:46.234'))
-
-      expect(esday().format(formatString)).toBe(expected)
-    },
-  )
-
   it.each([
     { formatString: 'H', expected: '3' },
     { formatString: 'HH', expected: '03' },
@@ -135,7 +126,7 @@ describe('format', () => {
     expect(esday().format(formatString)).toBe(expected)
   })
 
-  it('current date and time using "Z" to "??"', () => {
+  it('current date and time using "Z" to "nn:mm"', () => {
     const esdayDate = esday()
     const format = 'Z'
 

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -143,50 +143,6 @@ describe('format', () => {
   })
 })
 
-describe('conversion', () => {
-  const fakeTimeAsString = '2023-12-17T03:24:46.234Z'
-
-  beforeEach(() => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(fakeTimeAsString))
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('to unix timestamp (milliseconds)', () => {
-    expect(esday().valueOf()).toBe(1702783486234)
-  })
-
-  it('to unix timestamp (seconds)', () => {
-    expect(esday().unix()).toBe(1702783486)
-  })
-
-  it('toDate', () => {
-    const base = esday()
-    const jsDate = base.toDate()
-
-    expect(jsDate).toEqual(new Date())
-    expect(jsDate.toUTCString()).toBe(base.toString())
-
-    jsDate.setFullYear(1970)
-    expect(jsDate.toUTCString()).not.toBe(base.toString())
-  })
-
-  it('toJSON with valid date creates ISO8601 format', () => {
-    expect(esday().toJSON()).toBe(fakeTimeAsString)
-  })
-
-  it('toJSON with invalid date', () => {
-    expect(esday('otherString').toJSON()).toBe(null)
-  })
-
-  it('toISOString', () => {
-    expect(esday().toISOString()).toBe(fakeTimeAsString)
-  })
-})
-
 describe('extend formatting token definitions', () => {
   it.each([
     { formatString: 'YYYY PP', sourceString: '2024 3', expected: '2024 [special token PP] 2024' },

--- a/test/plugins/advancedFormat.test.ts
+++ b/test/plugins/advancedFormat.test.ts
@@ -1,6 +1,6 @@
 import { esday } from 'esday'
-import { expectSame } from '../util'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { expectSame } from '../util'
 
 import advancedFormatPlugin from '~/plugins/advancedFormat'
 

--- a/test/plugins/advancedFormat.test.ts
+++ b/test/plugins/advancedFormat.test.ts
@@ -1,0 +1,70 @@
+import { esday } from 'esday'
+import { expectSame } from '../util'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import advancedFormatPlugin from '~/plugins/advancedFormat'
+
+esday.extend(advancedFormatPlugin)
+
+describe('advancedFormat plugin', () => {
+  const fakeTimeAsString = '2023-12-17T03:24:46.234'
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(fakeTimeAsString))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not break core module without template', () => {
+    const sourceString = '2023-08-14T21:43:12.123'
+
+    expectSame((esday) => esday(sourceString).format())
+  })
+
+  it.each([
+    {
+      sourceString: '2023-08-14T21:43:12.123',
+      formatString: 'MM-YYYY-DD HH:mm:ss.SSS',
+      expected: '08-2023-14 21:43:12.123',
+    },
+    {
+      sourceString: '2023-08-14T21:43:12.123',
+      formatString: 'YYYY-MM-DD [MM] HH [any other text] mm [m]b',
+      expected: '2023-08-14 MM 21 any other text 43 mb',
+    },
+  ])(
+    'does not break core module with template "$formatString"',
+    ({ sourceString, formatString, expected }) => {
+      expectSame((esday) => esday(sourceString).format(formatString))
+      expect(esday(sourceString).format(formatString)).toBe(expected)
+    },
+  )
+
+  it.each([
+    { sourceString: '2024-08-14T21:43:12.123', formatString: 'd', expected: '3' },
+    { sourceString: '2024-08-14T21:43:12.123', formatString: 'S', expected: '1' },
+    { sourceString: '2024-08-14T21:43:12.123', formatString: 'SS', expected: '12' },
+    { sourceString: '2024-08-14T21:43:12.123Z', formatString: 'x', expected: '1723671792123' },
+    { sourceString: '2024-08-14T21:43:12.123Z', formatString: 'X', expected: '1723671792' },
+    { sourceString: '2024-08-14T01:43:12.123', formatString: 'k', expected: '1' },
+    { sourceString: '2024-08-14T00:43:12.123', formatString: 'k', expected: '24' },
+    { sourceString: '2024-08-14T14:43:12.123', formatString: 'kk', expected: '14' },
+    { sourceString: '2024-08-14T00:43:12.123', formatString: 'kk', expected: '24' },
+  ])(
+    'formats date using added token "$formatString"',
+    ({ sourceString, formatString, expected }) => {
+      expect(esday(sourceString).format(formatString)).toBe(expected)
+      expectSame((esday) => esday(sourceString).format(formatString))
+    },
+  )
+
+  it('current date and time using "ZZ" to "nnmm"', () => {
+    const esdayDate = esday()
+    const format = 'ZZ'
+
+    expect(esdayDate.format(format)).toMatch(/[+-]\d{4}/)
+  })
+})

--- a/test/plugins/utc.test.ts
+++ b/test/plugins/utc.test.ts
@@ -261,21 +261,21 @@ describe('plugin utc', () => {
       expect(esdayDate.format(format)).toBe(momentDate.format(format))
     })
 
-    it('using "HH-hh-mm-ss-SSS-Z-ZZ" parsing "2018-09-06T19:34:28.657Z"', () => {
+    it('using "HH-mm-ss-SSS-Z" parsing "2018-09-06T19:34:28.657Z"', () => {
       const dateString = '2018-09-06T19:34:28.657Z'
       const esdayDate = esday.utc(dateString)
-      const format = 'HH-hh-mm-ss-SSS-Z-ZZ'
+      const format = 'HH-mm-ss-SSS-Z'
 
-      expect(esdayDate.format(format)).toBe('19-07-34-28-657-+00:00-+0000')
+      expect(esdayDate.format(format)).toBe('19-34-28-657-+00:00')
       expect(esdayDate.format(format)).toBe(moment.utc(dateString).format(format))
     })
 
-    it('using "HH-hh-mm-ss-SSS-Z-ZZ" converting "2018-09-06T19:34:28.657Z"', () => {
+    it('using "HH-mm-ss-SSS-Z" converting "2018-09-06T19:34:28.657Z"', () => {
       const dateString = '2018-09-06T19:34:28.657Z'
       const esdayDate = esday(dateString).utc()
-      const format = 'HH-hh-mm-ss-SSS-Z-ZZ'
+      const format = 'HH-mm-ss-SSS-Z'
 
-      expect(esdayDate.format(format)).toBe('19-07-34-28-657-+00:00-+0000')
+      expect(esdayDate.format(format)).toBe('19-34-28-657-+00:00')
       expect(esdayDate.format(format)).toBe(moment.utc(dateString).format(format))
     })
   })


### PR DESCRIPTION
Redistributed parsing tokens.

As now it is very easy to add a formatting token in a plugin, I supposed that we add formatting tokens in the corresponding plugins (e.g. QuarterOfYear) and do not make AdvancedFormat require those plugins.