### PR TITLE
Feat: make month setter compatible with current momentjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ esday('2024-12-10').set('year', 2025).add(1, 'month').isToday()
 - **Locale is a Plugin**: no default locale!
 - **default value for 'Start of Week' is 1 (as in ISO 8601)**: 'Start of Week' is 1 ('Monday').
 - **default value for 'Start of Year' is 4 (as in ISO 8601)**: 'Start of Year' is 4.
+- **clamping month on set**: when changing the month and the new month does not have enough days to keep the current day of month, esday behaves like moment.js and clamps to the end of the target month
 
 ## Differences to Moment.js
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:run": "vitest --run",
     "test:run:tz1": "TZ=Pacific/Auckland vitest --run",
     "test:run:tz2": "TZ=Asia/Kathmandu vitest --run",
-    "test:run-browser": "vitest --run --browser.enabled --testTimeout=30000 --exclude test/plugins/weekOfYear.ar.test.ts --exclude test/plugins/weekOfYear.de.test.ts",
+    "test:run-browser": "vitest --run --browser.enabled --testTimeout=30000",
     "test:coverage": "vitest run --coverage",
     "release": "commit-and-tag-version -i CHANGELOG.md --same-file",
     "lint-commits": "commitlint --from b4c0a8614dd7d9997 --to HEAD --verbose",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@playwright/test": "~1.49.1",
     "@types/node": "^22.13.4",
     "@vitest/browser": "3.0.5",
-    "@vitest/coverage-v8": "^3.0.5",
+    "@vitest/coverage-v8": "3.0.5",
     "@vitest/ui": "3.0.5",
     "commit-and-tag-version": "^12.5.0",
     "cpy-cli": "^5.0.0",
@@ -64,7 +64,7 @@
     "tsup": "^8.3.6",
     "typescript": "^5.7.3",
     "vite": "^6.1.0",
-    "vitest": "v3.0.5"
+    "vitest": "3.0.5"
   },
   "commit-and-tag-version": {
     "packageFiles": [

--- a/src/core/EsDay.ts
+++ b/src/core/EsDay.ts
@@ -24,8 +24,8 @@ import { startOfImpl } from './Impl/startOf'
 export declare interface EsDay {
   year: (() => number) & ((year: number, month?: number, date?: number) => EsDay)
   month: (() => number) & ((month: number, date?: number) => EsDay)
-  date: (() => number) & ((date: number) => EsDay)
-  day: (() => number) & ((day: number) => EsDay)
+  date: (() => number) & ((date: number) => EsDay) // day of month
+  day: (() => number) & ((day: number) => EsDay) // day of week
   hour: (() => number) & ((hours: number, min?: number, sec?: number, ms?: number) => EsDay)
   minute: (() => number) & ((min: number, sec?: number, ms?: number) => EsDay)
   second: (() => number) & ((sec: number, ms?: number) => EsDay)
@@ -278,6 +278,13 @@ export class EsDay {
   private $set(unit: Exclude<UnitType, UnitWeek | UnitQuarter>, values: number[]) {
     if (prettyUnit(unit) === C.DAY) {
       setUnitInDate(this.$d, C.DATE_OF_WEEK, this.date() + (values[0] - this.day()))
+    } else if (prettyUnit(unit) === C.MONTH) {
+      const originalDate = values.length === 1 ? this.date() : values[1]
+      setUnitInDate(this.$d, unit as Exclude<typeof unit, UnitDay>, values)
+      if (originalDate > 0 && this.date() !== originalDate) {
+        // reset date to last day of previous month
+        setUnitInDate(this.$d, C.DATE_OF_WEEK, 0)
+      }
     } else {
       setUnitInDate(this.$d, unit as Exclude<typeof unit, UnitDay>, values)
     }

--- a/src/core/Impl/startOf.ts
+++ b/src/core/Impl/startOf.ts
@@ -22,7 +22,7 @@ export function startOfImpl(that: EsDay, unit: UnitType, reverse = false) {
 
   const $month = result.month()
   const $date = result.date()
-  const $day = result.day()
+  const $dayOfWeek = result.day()
 
   switch (prettyUnit(unit)) {
     case C.YEAR:
@@ -34,11 +34,11 @@ export function startOfImpl(that: EsDay, unit: UnitType, reverse = false) {
       instanceFactorySet(C.HOUR, 0)
       break
     case C.WEEK: {
-      // default start of week is Monday
-      // according to ISO 8601
+      // default start of week is Monday (according to ISO 8601)
       const weekStart = C.INDEX_MONDAY
-      const diff = ($day < weekStart ? $day + 7 : $day) - weekStart
-      instanceFactory(reverse ? $date + (6 - diff) : $date - diff, $month)
+      const diff = ($dayOfWeek < weekStart ? $dayOfWeek + 7 : $dayOfWeek) - weekStart
+      const newDate = reverse ? $date + (6 - diff) : $date - diff
+      setterFunc.call(result, C.DATE_OF_WEEK, [newDate])
       instanceFactorySet(C.HOUR, 0)
       break
     }

--- a/src/plugins/locale/index.ts
+++ b/src/plugins/locale/index.ts
@@ -139,7 +139,7 @@ const localePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
       const diff = ($day < weekStart ? $day + 7 : $day) - weekStart
 
       return origin
-        .month(origin.month(), reverse ? $date + (6 - diff) : $date - diff)
+        .date(reverse ? $date + (6 - diff) : $date - diff)
         .hour(inst.hour(), inst.minute(), inst.second(), inst.millisecond())
     }
 

--- a/test/add.test.ts
+++ b/test/add.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import { C } from '~/common'
 import type { UnitType } from '~/common/units'
 import { esday } from '~/core'
+import { expectSameResult } from './util'
 
 describe('add', () => {
   it.each([
@@ -18,9 +20,42 @@ describe('add', () => {
       format: 'YYYY-MM-DD HH:mm:ss.SSS',
       expected: '2021-01-01 00:00:00.001',
     },
-  ])('add $value $unit to get $expected', ({ value, unit, format, expected }) => {
+  ])('basic - add $value $unit to get $expected', ({ value, unit, format, expected }) => {
     const inst = esday('2021-01-01')
 
     expect(inst.add(value, unit as UnitType).format(format)).toBe(expected)
   })
+
+  it.each([
+    {
+      sourceString: '2024-01-31T13:24:35.789',
+      addedValue: 1,
+      addUnit: C.DAY,
+      expected: '2024-02-01T13:24:35',
+    },
+    {
+      sourceString: '2023-01-28T13:24:35.789',
+      addedValue: 1,
+      addUnit: C.MONTH,
+      expected: '2023-02-28T13:24:35',
+    },
+    {
+      sourceString: '2024-01-31T13:24:35.789',
+      addedValue: 1,
+      addUnit: C.MONTH,
+      expected: '2024-02-29T13:24:35',
+    },
+    {
+      sourceString: '2023-12-31T13:24:35.789',
+      addedValue: 1,
+      addUnit: C.YEAR,
+      expected: '2024-12-31T13:24:35',
+    },
+  ])(
+    'edge case - add $value $unit to get $expected',
+    ({ sourceString, addedValue, addUnit, expected }) => {
+      expectSameResult((esday) => esday(sourceString).add(addedValue, addUnit))
+      expect(esday(sourceString).add(addedValue, addUnit).format().slice(0, -6)).toBe(expected)
+    },
+  )
 })

--- a/test/getset.test.ts
+++ b/test/getset.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
+import { C } from '~/common'
 import type { EsDay } from '~/core'
 import { esday } from '~/core'
+import { expectSame, expectSameResult } from './util'
 
 describe('get', () => {
   const testYear = 2024
@@ -37,11 +39,15 @@ describe('get', () => {
     expect(testDate.get('date')).toBe(testDay)
     expect(testDate.get('D')).toBe(testDay)
   })
-
-  it('day of week', () => {
-    const dayOfWeek = 6
-    expect(testDate.day()).toBe(dayOfWeek)
-    expect(testDate.get('day')).toBe(dayOfWeek)
+  it.each([
+    { sourceString: '2024-02-03T13:14:15.678', expected: 6 },
+    { sourceString: '2024-11-06T00:00:00', expected: 3 },
+    { sourceString: '2024-11-14T00:00:00', expected: 4 },
+  ])('day of week for "$sourceString"', ({ sourceString, expected }) => {
+    expect(esday(sourceString).day()).toBe(expected)
+    expect(esday(sourceString).get('day')).toBe(expected)
+    expectSame((esday) => esday(sourceString).get(C.DATE_OF_WEEK))
+    expectSame((esday) => esday(sourceString).day())
   })
 
   it('hour', () => {
@@ -148,6 +154,14 @@ describe('set', () => {
       const modifiedDate = testDate.set('M', 5)
 
       expect(modifiedDate.toISOString()).toBe(resultDateAsIso)
+    })
+
+    it.each([
+      { sourceString: '2024-03-15T17:16:15', newMonth: 7 },
+      { sourceString: '2023-01-31T23:59:59', newMonth: 1 },
+      { sourceString: '2023-01-31T23:59:59', newMonth: 2 },
+    ])('set month of "$sourceString" to "$newMonth"', ({ sourceString, newMonth }) => {
+      expectSameResult((esday) => esday(sourceString).month(newMonth - 1))
     })
   })
 

--- a/test/plugins/weekOfYear.ar.test.ts
+++ b/test/plugins/weekOfYear.ar.test.ts
@@ -1,18 +1,23 @@
-/**
- * This test fails in vitest browser mode as the locale 'ar' of moment is not loaded
- */
 import { esday } from 'esday'
 import moment from 'moment'
 import { describe, expect, it } from 'vitest'
 import localeAr from '~/locales/ar'
-import { expectSame } from '../util'
-import 'moment/locale/ar'
 import { localePlugin, weekOfYearPlugin } from '~/plugins'
+import { expectSame } from '../util'
 
 esday.extend(localePlugin).extend(weekOfYearPlugin)
 esday.registerLocale(localeAr)
 esday.locale('ar')
-moment.locale('ar')
+
+//make the default moment locale use the required settings compatible
+// with locale 'ar', as in vitest browser mode we cannot load a moment
+// locale in the head element.
+moment.updateLocale('en', {
+  week: {
+    dow: 6, // First day of week is Saturday
+    doy: 12, // First week of year must contain 1 January (7 + 6 - 1)
+  },
+})
 
 // Tests with Friday as start of week
 describe('week plugin - locale "ar"', () => {

--- a/test/plugins/weekOfYear.de.test.ts
+++ b/test/plugins/weekOfYear.de.test.ts
@@ -1,7 +1,3 @@
-/**
- * This test fails in vitest browser mode as the locale 'de' of moment is not loaded
- */
-
 import { esday } from 'esday'
 import moment from 'moment'
 import { describe, expect, it } from 'vitest'
@@ -12,7 +8,16 @@ import { expectSame } from '../util'
 esday.extend(localePlugin).extend(weekOfYearPlugin)
 esday.registerLocale(localeDe)
 esday.locale('de')
-moment.locale('de')
+
+//make the default moment locale use the required settings compatible
+// with locale 'de', as in vitest browser mode we cannot load a moment
+// locale in the head element.
+moment.updateLocale('en', {
+  week: {
+    dow: 1, // First day of week is Monday
+    doy: 4, // First week of year must contain 4 January (7 + 1 - 4)
+  },
+})
 
 // Tests with Monday as start of week
 describe('week plugin - locale "de"', () => {

--- a/test/plugins/weekOfYear.en.test.ts
+++ b/test/plugins/weekOfYear.en.test.ts
@@ -8,8 +8,7 @@ import { expectSame } from '../util'
 
 esday.extend(localePlugin).extend(weekOfYearPlugin)
 esday.registerLocale(localeEn)
-esday.locale('en')
-moment.locale('en')
+// we do not have to call 'moment.locale('en')' as this is the default locale
 
 // Tests with Sunday as start of week
 describe('week plugin - locale "en"', () => {

--- a/test/startOf.test.ts
+++ b/test/startOf.test.ts
@@ -1,6 +1,11 @@
+import moment from 'moment'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DATE_OF_WEEK, DAY, HOUR, MIN, MONTH, SECOND, WEEK, YEAR } from '~/common/constants'
 import { esday } from '~/core'
+import { expectSameResult } from './util'
+
+// make moment use an ISO 8601 compatible locale
+moment.locale('en-GB')
 
 describe('startOf', () => {
   // => format uses null as offset
@@ -30,6 +35,17 @@ describe('startOf', () => {
 
     expect(resultDate.format('YYYY-MM-DDTHH:mm:ss.SSS')).toBe(expectedAsString)
   })
+
+  it.each([
+    { sourceString: '2024-01-01T00:00:00' },
+    { sourceString: '2023-12-31T00:00:00' },
+    { sourceString: '2023-11-12T00:00:00' },
+    { sourceString: '2023-11-13T00:00:00' },
+    { sourceString: '2023-11-14T00:00:00' },
+    { sourceString: '2023-05-07T00:00:00' },
+  ])('for edge case "$sourceString"', ({ sourceString }) => {
+    expectSameResult((esday) => esday(sourceString).startOf(WEEK))
+  })
 })
 
 describe('endOf', () => {
@@ -57,5 +73,16 @@ describe('endOf', () => {
     const resultDate = esday().endOf(unit)
 
     expect(resultDate.format('YYYY-MM-DDTHH:mm:ss.SSS')).toBe(expectedAsString)
+  })
+
+  it.each([
+    { sourceString: '2024-01-01T00:00:00' },
+    { sourceString: '2023-12-31T00:00:00' },
+    { sourceString: '2023-11-12T00:00:00' },
+    { sourceString: '2023-11-13T00:00:00' },
+    { sourceString: '2023-11-14T00:00:00' },
+    { sourceString: '2023-05-07T00:00:00' },
+  ])('for edge case "$sourceString"', ({ sourceString }) => {
+    expectSameResult((esday) => esday(sourceString).endOf(WEEK))
   })
 })

--- a/test/startOf.test.ts
+++ b/test/startOf.test.ts
@@ -4,8 +4,15 @@ import { DATE_OF_WEEK, DAY, HOUR, MIN, MONTH, SECOND, WEEK, YEAR } from '~/commo
 import { esday } from '~/core'
 import { expectSameResult } from './util'
 
-// make moment use an ISO 8601 compatible locale
-moment.locale('en-GB')
+//make the default moment locale use the required settings compatible
+// with ISO 8601, as in vitest browser mode we cannot load a moment
+// locale in the head element.
+moment.updateLocale('en', {
+  week: {
+    dow: 1, // First day of week is Monday
+    doy: 4, // First week of year must contain 4 January (7 + 1 - 4)
+  },
+})
 
 describe('startOf', () => {
   // => format uses null as offset


### PR DESCRIPTION
Make esday compatible with momentjs (version > 2.1):
 when changing the month and the new month does not have enough days to keep the current day of month, esday behaves like momentjs and clamps to the end of the target month