### PR TITLE
Refactor: make all overload signatures for getter/setter follow the same pattern

### DIFF
--- a/src/plugins/dayOfYear/index.ts
+++ b/src/plugins/dayOfYear/index.ts
@@ -2,16 +2,17 @@ import type { EsDayPlugin } from 'esday'
 
 declare module 'esday' {
   interface EsDay {
-    dayOfYear: (() => number) & ((dayOfYear: number) => EsDay)
+    dayOfYear(): number
+    dayOfYear(dayOfYear: number): EsDay
   }
 }
 
 const dayOfYearPlugin: EsDayPlugin<{}> = (_, dayClass, d) => {
-  // @ts-expect-error is ok
+  // @ts-expect-error function is compatible with its overload
   dayClass.prototype.dayOfYear = function (input?: number) {
     const dayOfYear =
       Math.round((d(this).startOf('day').valueOf() - d(this).startOf('year').valueOf()) / 864e5) + 1
-    return input == null ? dayOfYear : this.add(input - dayOfYear, 'day')
+    return input === undefined ? dayOfYear : this.add(input - dayOfYear, 'day')
   }
 }
 

--- a/src/plugins/locale/index.ts
+++ b/src/plugins/locale/index.ts
@@ -1,4 +1,4 @@
-import type { DateType, EsDay, EsDayFactory, EsDayPlugin, UnitType } from 'esday'
+import type { DateType, EsDay, EsDayPlugin, UnitType } from 'esday'
 import { C, prettyUnit, undefinedOr } from '~/common'
 import en from '~/locales/en'
 import type { Locale } from './types'
@@ -94,19 +94,18 @@ const localePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
     return getLocale(getSetPrivateLocaleName(this))
   }
 
-  // add locale getter / setter
-  dayClass.prototype.locale = function <T extends string | undefined>(
-    localeName?: T,
-  ): T extends string ? EsDay : string {
+  // @ts-expect-error function is compatible with its overload
+  dayClass.prototype.locale = function (localeName?: string) {
     // dayClass.prototype.locale = function (localeName?: string): any {
-    if (localeName !== undefined && typeof localeName === 'string') {
-      const inst = this.clone()
-      getSetPrivateLocaleName(inst, localeName)
-      // biome-ignore lint/suspicious/noExplicitAny: required to enable getter/setter function
-      return inst as any
+    if (localeName === undefined) {
+      // Getter
+      return getSetPrivateLocaleName(this)
     }
-    // biome-ignore lint/suspicious/noExplicitAny: required to enable getter/setter function
-    return getSetPrivateLocaleName(this) as any
+
+    // Setter
+    const inst = this.clone()
+    getSetPrivateLocaleName(inst, localeName)
+    return inst
   }
 
   // set $l in clone method
@@ -153,17 +152,16 @@ const localePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
     return fixDiff(inst, this, unit, true)
   }
 
-  // setter / getter for global locale
-  dayFactory.locale = <T extends string | undefined>(
-    localeName?: T,
-  ): T extends string ? EsDayFactory : string => {
-    if (localeName !== undefined && typeof localeName === 'string') {
-      $localeGlobal = localeName
-      // biome-ignore lint/suspicious/noExplicitAny: required to enable getter/setter function
-      return dayFactory as any
+  // @ts-expect-error function is compatible with its overload
+  dayFactory.locale = (localeName?: string) => {
+    if (localeName === undefined) {
+      // Getter
+      return $localeGlobal
     }
-    // biome-ignore lint/suspicious/noExplicitAny: required to enable getter/setter function
-    return $localeGlobal as any
+
+    // Setter
+    $localeGlobal = localeName
+    return dayFactory
   }
 
   dayFactory.registerLocale = (locale: Locale, newName?: string) => {

--- a/src/plugins/locale/types.ts
+++ b/src/plugins/locale/types.ts
@@ -7,30 +7,17 @@ type ReadonlyTuple<T, N extends number, R extends readonly T[] = []> = R['length
 
 declare module 'esday' {
   interface EsDay {
-    /**
-     * overloads for getter / setter of locale of instance
-     * locale(): string
-     * locale(localeName: string): EsDay
-     */
-    locale: <T extends string | undefined = undefined>(
-      localeName?: T,
-    ) => T extends string ? EsDay : string
-
+    locale(): string
+    locale(localeName: string): EsDay
     localeObject: () => Locale
   }
 
   interface EsDayFactory {
-    /**
-     * overloads for getter / setter of locale of prototype
-     * locale(): string
-     * locale(localeName: string): EsDay
-     */
-    locale: <T extends string | undefined = undefined>(
-      localeName?: T,
-    ) => T extends string ? EsDayFactory : string
+    locale(): string
+    locale(localeName: string): EsDay
 
     /**
-     * register locale
+     * add locale to list of available Locales
      */
     registerLocale: (locale: Locale, newName?: string) => EsDayFactory
   }

--- a/src/plugins/quarterOfYear/index.ts
+++ b/src/plugins/quarterOfYear/index.ts
@@ -3,32 +3,23 @@ import { C, prettyUnit } from '~/common'
 
 declare module 'esday' {
   interface EsDay {
-    /**
-     * overloads for getter / setter of locale of instance
-     * quarter(): number
-     * quarter(quarterNumber: number): EsDay
-     */
-    quarter: <T extends number | undefined = undefined>(
-      quarterNumber?: T,
-    ) => T extends number ? EsDay : number
+    quarter(): number
+    quarter(quarterNumber: number): EsDay
   }
 }
 
 const quarterOfYearPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory: EsDayFactory) => {
   const proto = dayClass.prototype
 
-  proto.quarter = function <T extends number | undefined = undefined>(
-    quarterNumber?: T,
-  ): T extends number ? EsDay : number {
-    // Setter
-    if (quarterNumber !== undefined) {
-      // biome-ignore lint/suspicious/noExplicitAny: required to enable getter/setter function
-      return this.month((this.month() % 3) + (quarterNumber - 1) * 3) as any
+  // @ts-expect-error function is compatible with its overload
+  proto.quarter = function (quarterNumber?: number) {
+    if (quarterNumber === undefined) {
+      // Getter
+      return Math.ceil((this.month() + 1) / 3)
     }
 
-    // Getter
-    // biome-ignore lint/suspicious/noExplicitAny: required to enable getter/setter function
-    return Math.ceil((this.month() + 1) / 3) as any
+    // Setter
+    return this.month((this.month() % 3) + (quarterNumber - 1) * 3)
   }
 
   const oldAdd = proto.add

--- a/src/plugins/utc/index.ts
+++ b/src/plugins/utc/index.ts
@@ -48,7 +48,8 @@ declare module 'esday' {
     local: () => EsDay
     isUTC: () => boolean
     utcOffset(): number
-    utcOffset(offset: number | string, keepLocalTime?: boolean): EsDay
+    utcOffset(offset: number | string): EsDay
+    utcOffset(offset: number | string, keepLocalTime: boolean): EsDay
   }
 
   interface EsDayFactory {
@@ -99,12 +100,15 @@ const utcPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
     return C.INVALID_DATE_STRING
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: did not find a conditional return type a a replacement for 'any'
-  proto.utcOffset = function (offset?: number | string, keepLocalTime?: boolean): any {
+  // @ts-expect-error function is compatible with its overload
+  proto.utcOffset = function (offset?: number | string, keepLocalTime?: boolean) {
     if (offset === undefined) {
+      // Getter
       const defaultOffset = -Math.round(this['$d'].getTimezoneOffset())
       return utcOffsetGetImpl(this, defaultOffset)
     }
+
+    // Setter
     return utcOffsetSetImpl(this, offset, keepLocalTime)
   }
 

--- a/src/plugins/week/index.ts
+++ b/src/plugins/week/index.ts
@@ -2,10 +2,11 @@ import type { EsDayPlugin } from 'esday'
 import { C } from '~/common'
 
 declare module 'esday' {
-  // TODO fix getter / setter signatures
   interface EsDay {
-    week: (() => number) & ((week: number) => EsDay)
-    weeks: (() => number) & ((week: number) => EsDay)
+    week(): number
+    week(week: number): EsDay
+    weeks(): number
+    weeks(week: number): EsDay
     weekYear: () => number
   }
 }
@@ -14,7 +15,7 @@ const weekPlugin: EsDayPlugin<{}> = (_, dayClass) => {
   // @ts-expect-error function is compatible with its overload
   dayClass.prototype.week = function (week?: number) {
     // Setter
-    if (week) {
+    if (week !== undefined) {
       return this.add((week - this.week()) * 7, C.DAY)
     }
 

--- a/test/plugins/utc.test.ts
+++ b/test/plugins/utc.test.ts
@@ -1,4 +1,4 @@
-import type { EsDay, UnitType } from 'esday'
+import type { UnitType } from 'esday'
 import { esday } from 'esday'
 import moment from 'moment/min/moment-with-locales'
 
@@ -387,7 +387,7 @@ describe('plugin utc', () => {
     })
 
     it('returns a number', () => {
-      const offsetValue: number = esday().utcOffset()
+      const offsetValue = esday().utcOffset()
 
       expect(offsetValue).toBeTypeOf('number')
     })
@@ -421,7 +421,7 @@ describe('plugin utc', () => {
     })
 
     it('returns an instance of EsDay', () => {
-      const newDate: EsDay = esday().utcOffset(5)
+      const newDate = esday().utcOffset(5)
 
       expect(newDate).toHaveProperty('valueOf')
     })


### PR DESCRIPTION
The structure of the getter/setter overloads in the plugins was quite inhomogeneous.
To give the library a consistent style, I changed all occurrences to a consistent style following this example:

```
declare module 'esday' {
  interface EsDay {
    quarter(): number
    quarter(quarterNumber: number): EsDay
  }
}

// @ts-expect-error function is compatible with its overload
proto.quarter = function (quarterNumber?: number) {
  if (quarterNumber === undefined) {
    // Getter
    return Math.ceil((this.month() + 1) / 3)
  }
 
  // Setter
  return this.month((this.month() % 3) + (quarterNumber - 1) * 3)
}
```