### PR TITLE
Fix: parsing day-of-month-only now returns current month

### DIFF
--- a/src/core/EsDay.ts
+++ b/src/core/EsDay.ts
@@ -73,15 +73,16 @@ export class EsDay {
     ms: number | undefined,
     offsetMs?: number,
   ) {
-    const parsedYearOrDefault = Y === undefined ? new Date().getFullYear() : Y
+    const parsedYearOrDefault = Y ?? new Date().getFullYear()
+    const parsedMonthOrDefault = M ?? (Y !== undefined ? 1 : new Date().getMonth() + 1)
     const dateComponents = {
       Y: parsedYearOrDefault,
-      M: (M || 1) - 1,
-      D: D || 1,
-      h: h || 0,
-      m: m || 0,
-      s: s || 0,
-      ms: ms || 0,
+      M: parsedMonthOrDefault - 1,
+      D: D ?? 1,
+      h: h ?? 0,
+      m: m ?? 0,
+      s: s ?? 0,
+      ms: ms ?? 0,
     }
 
     const yearWithoutCentury = Math.abs(parsedYearOrDefault) < 100

--- a/src/plugins/utc/index.ts
+++ b/src/plugins/utc/index.ts
@@ -146,15 +146,16 @@ const utcPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
       return oldDateFromDateComponents(Y, M, D, h, m, s, ms, offsetMs)
     }
 
-    const parsedYearOrDefault = Y === undefined ? new Date().getFullYear() : Y
+    const parsedYearOrDefault = Y ?? new Date().getFullYear()
+    const parsedMonthOrDefault = M ?? (Y !== undefined ? 1 : new Date().getMonth() + 1)
     const dateComponents = {
       Y: parsedYearOrDefault,
-      M: (M || 1) - 1,
-      D: D || 1,
-      h: h || 0,
-      m: m || 0,
-      s: s || 0,
-      ms: ms || 0,
+      M: parsedMonthOrDefault - 1,
+      D: D ?? 1,
+      h: h ?? 0,
+      m: m ?? 0,
+      s: s ?? 0,
+      ms: ms ?? 0,
     }
 
     const yearWithoutCentury = Math.abs(parsedYearOrDefault) < 100

--- a/test/plugins/advancedParse.test.ts
+++ b/test/plugins/advancedParse.test.ts
@@ -74,6 +74,18 @@ describe('advancedParse plugin - local mode', () => {
     })
 
     it.each([
+      { formatString: 'D', sourceString: '8' },
+      { formatString: 'D', sourceString: '08' },
+      { formatString: 'D', sourceString: '11' },
+    ])(
+      'parse day of month "$sourceString" with "$formatString"',
+      ({ sourceString, formatString }) => {
+        expectSameResult((esday) => esday(sourceString, formatString))
+        expect(esday(sourceString, formatString).isValid()).toBeTruthy()
+      },
+    )
+
+    it.each([
       { formatString: 'S', sourceString: '0', expectedMS: 0 },
       { formatString: 'S', sourceString: '3', expectedMS: 300 },
       { formatString: 'S', sourceString: '14', expectedMS: 140 },
@@ -105,6 +117,7 @@ describe('advancedParse plugin - local mode', () => {
       { formatString: 'MM-YYYY-DD HH:mm:ss.SSS', sourceString: '8-2023-4 1:3:2.3' },
       { formatString: 'M-YY-D H:m:s.SS', sourceString: '08-2023-14 21:43:12.123' },
       { formatString: 'M-YY-D H:m:s.SS', sourceString: '8-23-4 1:3:2.3' },
+      { formatString: 'YYYY DD', sourceString: '2025 14' },
       { formatString: 'Q YYYY', sourceString: '1 2023' },
       { formatString: 'Q YYYY', sourceString: '2 2023' },
       { formatString: 'Q YYYY', sourceString: '3 2023' },


### PR DESCRIPTION
parsing day-of-month-only now returns current month (as moment.ja)