### PR TITLE
Fix: some minor effects in advancedParse plugin

### DIFF
--- a/docs/plugins/advancedParse.md
+++ b/docs/plugins/advancedParse.md
@@ -6,8 +6,7 @@ AdvancedParse extends the `esday` constructor to support custom formats of input
 
 If used together with plugin utc, the plugin utc must be activated before the plugin AdvancedParse.
 
-## Method signatures
-### Parsing with a given format:
+### Method signatures
 ```typescript
 esday(date: string, format: string): EsDay
 esday(date: string, format: string[]): EsDay
@@ -92,6 +91,11 @@ interface ParsedElements {
 | ZZ        | \-0500        | Compact offset from UTC, 2-digits  as `+-HH:mm`, `+-HHmm`, or `Z`    |
 | X         | 1410715640579 | Unix timestamp                                                       |
 | x         | 1410715640579 | Unix ms timestamp                                                    |
+
+## Dependencies
+AdvancedParse requires no other plugin.
+
+AdvancedParse can be used together with the plugin Utc that must be loaded using esday.extend(...) before the plugin AdvancedParse.
 
 ## Examples
 ### Parsing

--- a/src/plugins/advancedParse/index.ts
+++ b/src/plugins/advancedParse/index.ts
@@ -349,7 +349,7 @@ function makeParser(format: string, isStrict: boolean): { parser: Parser; postPa
   ): Date => {
     let modifiedParsedDate = parsedDate
     for (let i = 0; i < postParseHandlers.length; i++) {
-      modifiedParsedDate = postParseHandlers[i](parsedDate, parsedElements, parseOptions)
+      modifiedParsedDate = postParseHandlers[i](modifiedParsedDate, parsedElements, parseOptions)
     }
 
     return modifiedParsedDate

--- a/src/plugins/advancedParse/index.ts
+++ b/src/plugins/advancedParse/index.ts
@@ -451,7 +451,8 @@ const advancedParsePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
     const format = this['$conf'].args_1
     const arg2 = this['$conf'].args_2
     const arg3 = this['$conf'].args_3
-    const parseOptions: ParseOptions = (this['$conf'].parseOptions as ParseOptions) ?? {}
+    this['$conf'].parseOptions ??= {} as ParseOptions
+    const parseOptions: ParseOptions = this['$conf'].parseOptions as ParseOptions
 
     let isStrict = false
     if (typeof arg2 === 'boolean') {

--- a/src/plugins/advancedParse/index.ts
+++ b/src/plugins/advancedParse/index.ts
@@ -12,7 +12,7 @@
  *   parseOptions     ParseOptions object containing parsing options
  */
 
-import type { DateFromDateComponents, DateType, EsDay, EsDayFactory, EsDayPlugin } from 'esday'
+import type { DateFromDateComponents, DateType, EsDay, EsDayPlugin } from 'esday'
 import { isArray, isString, isUndefined, isValidDate } from '~/common'
 import type {
   ParseOptions,
@@ -440,11 +440,7 @@ function addParseTokenDefinitions(newTokens: TokenDefinitions) {
   formattingTokensRegexFromDefinitions()
 }
 
-const advancedParsePlugin: EsDayPlugin<{}> = (
-  _,
-  dayClass: typeof EsDay,
-  dayFactory: EsDayFactory,
-) => {
+const advancedParsePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
   const proto = dayClass.prototype
 
   // get regexp to separate format into formatting tokens and separators
@@ -464,7 +460,7 @@ const advancedParsePlugin: EsDayPlugin<{}> = (
       isStrict = arg3
     }
 
-    if (isString(d)) {
+    if (isString(d) && !isUndefined(format)) {
       // format as single string
       if (isString(format)) {
         const parsingResult = parseFormattedInput.call(this, d, format, isStrict, parseOptions)


### PR DESCRIPTION
These changes to the advancedParse plugin are required by the isoWeek plugin:

- do not ignore results of postParseHandlers
- make parse handle missing format
- make parse keep existing parseOptions