### PR TITLE
Fix: some minor effects in localizedParse plugin

### DIFF
--- a/docs/plugins/localizedParse.md
+++ b/docs/plugins/localizedParse.md
@@ -4,12 +4,6 @@ LocalizedParse extends the `esday` constructor to support localized formats of i
 
 The locale to use for parsing can be defined as 3rd parameter. If no locale is given, then the current global locale is used (defaults to 'en', which is a duplicate of 'en-US').
 
-## Prerequisites
-
-LocalizedParse requires the AdvancedParse plugin, the Locale plugin and one locale definition to be loaded.
-
-If the Utc plugin is used too, this must be loaded (`extend(..)`) before the AdvancedParse plugin; the LocalizedParse plugin must be loaded after these 2 plugins.
-
 ## Method signatures
 ```typescript
 esday(date: string, format: string): EsDay
@@ -64,6 +58,13 @@ If an array of formats is used, `date` will be parsed with the best matching for
 | ll        | Sep 4, 1986                         | Month name, day of month, year                    |
 | lll       | Sep 4, 1986 8:30 PM                 | Month name, day of month, year, time              |
 | llll      | Thu, Sep 4, 1986 8:30 PM            | Month name, day of month, day of week, year, time |
+
+## Dependencies
+LocalizedParse requires the plugins AdvancedParse and Locale and at least 1 registered and activated locale.
+
+The plugin AdvancedParse must be loaded using esday.extend(...) before the plugin LocalizedParse.
+
+LocalizedParse can be used together with the plugin Utc that must be loaded using esday.extend(...) before the plugin AdvancedParse.
 
 ## Examples
 Basic example with some localized tokens.

--- a/src/plugins/localizedFormat/index.ts
+++ b/src/plugins/localizedFormat/index.ts
@@ -4,7 +4,7 @@
  * This plugin adds localized formats to advancedFormat plugin and date formatting
  */
 
-import type { EsDay, EsDayFactory, EsDayPlugin, FormattingTokenDefinitions } from 'esday'
+import type { EsDay, EsDayPlugin, FormattingTokenDefinitions } from 'esday'
 import { isArray, isString, padNumberWithLeadingZeros } from '~/common'
 import type {
   DayNamesStandaloneFormat,
@@ -97,11 +97,7 @@ function replaceLocaleTokens(format: string, currentLocale: Locale) {
   return format.replace(localFormattingTokens, replaceLongDateFormatTokens)
 }
 
-const localizedFormatPlugin: EsDayPlugin<{}> = (
-  _,
-  dayClass: typeof EsDay,
-  dayFactory: EsDayFactory,
-) => {
+const localizedFormatPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
   const proto = dayClass.prototype
 
   // add new parsing tokens to existing list of parsing tokens
@@ -131,7 +127,10 @@ const localizedFormatPlugin: EsDayPlugin<{}> = (
     }
 
     const newFormat = replaceLocaleTokens(formatStr, this.localeObject())
-    return oldFormat.call(this, newFormat)
+    const formattedValue = oldFormat.call(this, newFormat)
+
+    // run postFormat if exists
+    return this.localeObject?.().postFormat?.(formattedValue) ?? formattedValue
   }
 }
 

--- a/src/plugins/localizedParse/index.ts
+++ b/src/plugins/localizedParse/index.ts
@@ -29,6 +29,8 @@ import type {
 } from '../index'
 import { getLocale } from '../locale'
 
+const DEFAULT_LOCALE = 'en'
+
 // Regular expressions for parsing
 const match2 = /\d{2}/
 const match1to2 = /\d\d?/
@@ -295,7 +297,7 @@ const localizedParsePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
     // handle locale name(s) as argument; use the locale of 'this'
     // as the default value, if no locale is given as 3rd calling
     // parameter (1st parameter is the date string).
-    let currentLocale = this.localeObject()
+    let currentLocale = this.localeObject?.() ?? DEFAULT_LOCALE
     const arg2 = this['$conf'].args_2
     if (!isUndefined(arg2) && typeof arg2 === 'string') {
       currentLocale = getLocale(arg2)

--- a/src/plugins/localizedParse/index.ts
+++ b/src/plugins/localizedParse/index.ts
@@ -15,7 +15,7 @@
  *   isUtc            evaluate date as utc
  */
 
-import type { DateType, EsDay, EsDayFactory, EsDayPlugin } from 'esday'
+import type { DateType, EsDay, EsDayPlugin } from 'esday'
 import { C, isArray, isString, isUndefined } from '~/common'
 import type {
   DayNames,
@@ -70,7 +70,7 @@ function meridiemMatch(locale: Locale, input: string, isLowerCase: boolean): boo
 /**
  * Create a function that will parse the input string as meridiem string and
  * add it to the given 'parsedElements' containing the date&time components.
- * @param isLowerCase - parse the meridiem string as lowercase)
+ * @param isLowerCase - parse the meridiem string as lowercase
  * @returns function that will add the given value to date&time component as 'afternoon'
  */
 function addAfternoon(isLowerCase: boolean) {
@@ -271,11 +271,7 @@ function replaceLocaleTokens(format: string, currentLocale: Locale) {
   return format.replace(localFormattingTokens, replaceLongDateFormatTokens)
 }
 
-const localizedParsePlugin: EsDayPlugin<{}> = (
-  _,
-  dayClass: typeof EsDay,
-  dayFactory: EsDayFactory,
-) => {
+const localizedParsePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
   const proto = dayClass.prototype
 
   // add new parsing tokens to existing list of parsing tokens


### PR DESCRIPTION
These changes to the localizedParse plugin are required by the isoWeek plugin:

- make localizedFormat run 'postFormat' from locale
- remove unnecessary types
- rename function parameter 'options' to 'parseOptions'
- make LocalizedParse use default locale 'en', if plugin locale is not loaded