### PR TITLE
feat: add plugin relativeTime

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -29,11 +29,11 @@ import localizedFormatPlugin from './localizedFormat'
 import localizedParsePlugin from './localizedParse'
 import minMaxPlugin from './minMax'
 import quarterOfYearPlugin from './quarterOfYear'
+import relativeTimePlugin from './relativeTime'
 import toArrayPlugin from './toArray'
 import toObjectPlugin from './toObject'
 import utcPlugin from './utc'
 import weekPlugin from './week'
-import relativeTimePlugin from './relativeTime'
 
 export {
   advancedFormatPlugin,

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -33,6 +33,7 @@ import toArrayPlugin from './toArray'
 import toObjectPlugin from './toObject'
 import utcPlugin from './utc'
 import weekPlugin from './week'
+import relativeTimePlugin from './relativeTime'
 
 export {
   advancedFormatPlugin,
@@ -52,6 +53,7 @@ export {
   toObjectPlugin,
   utcPlugin,
   weekPlugin,
+  relativeTimePlugin,
 }
 
 export type {

--- a/src/plugins/relativeTime/index.ts
+++ b/src/plugins/relativeTime/index.ts
@@ -32,7 +32,7 @@ type Threshold = {
   d?: typeof C.SECOND | typeof C.MIN | typeof C.HOUR | typeof C.DAY | typeof C.MONTH | typeof C.YEAR
 }
 
-const plugin: EsDayPlugin<{
+const relativeTimePlugin: EsDayPlugin<{
   thresholds?: Threshold[]
   rounding?: (n: number) => number
 }> = (options, Class, esday) => {
@@ -142,4 +142,4 @@ const plugin: EsDayPlugin<{
   }
 }
 
-export default plugin
+export default relativeTimePlugin

--- a/src/plugins/relativeTime/index.ts
+++ b/src/plugins/relativeTime/index.ts
@@ -1,0 +1,128 @@
+import type { DateType, EsDay, EsDayPlugin } from 'esday'
+import { C } from '~/common'
+import type { Locale, RelativeTimeKeys } from '../locale'
+
+declare module 'esday' {
+  interface EsDay {
+    to: (input: DateType, withoutSuffix?: boolean) => string
+    from: (input: DateType, withoutSuffix?: boolean) => string
+    toNow: (withoutSuffix?: boolean) => string
+    fromNow: (withoutSuffix?: boolean) => string
+  }
+}
+
+type Threshold = {
+  l: RelativeTimeKeys
+  r?: number
+  d?: typeof C.SECOND | typeof C.MIN | typeof C.HOUR | typeof C.DAY | typeof C.MONTH | typeof C.YEAR
+}
+
+const plugin: EsDayPlugin<{
+  thresholds?: Threshold[]
+  rounding?: (n: number) => number
+}> = (options, Class, esday) => {
+  const proto = Class.prototype
+
+  const relObj: Locale['relativeTime'] = {
+    future: 'in %s',
+    past: '%s ago',
+    s: 'a few seconds',
+    ss: '%d seconds',
+    m: 'a minute',
+    mm: '%d minutes',
+    h: 'an hour',
+    hh: '%d hours',
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years',
+  }
+
+  const thresholds: Threshold[] = options.thresholds || [
+    { l: 's', r: 44, d: C.SECOND },
+    { l: 'm', r: 89 },
+    { l: 'mm', r: 44, d: C.MIN },
+    { l: 'h', r: 89 },
+    { l: 'hh', r: 21, d: C.HOUR },
+    { l: 'd', r: 35 },
+    { l: 'dd', r: 25, d: C.DAY },
+    { l: 'M', r: 45 },
+    { l: 'MM', r: 10, d: C.MONTH },
+    { l: 'y', r: 17 },
+    { l: 'yy', d: C.YEAR },
+  ]
+
+  const rounding = options.rounding || Math.round
+
+  function fromToBase(
+    input: DateType,
+    withoutSuffix: boolean,
+    instance: EsDay,
+    isFrom: boolean,
+    postFormat?: (s: string) => string,
+  ): string {
+    const inputInstance = esday(input)
+    if (!instance.isValid() || !inputInstance.isValid()) {
+      return C.INVALID_DATE_STRING
+    }
+
+    const locale = instance.localeObject?.()?.relativeTime || relObj
+    let result = 0
+    let out = ''
+    let isFuture = false
+
+    for (let i = 0; i < thresholds.length; i++) {
+      let t = thresholds[i]
+      if (t.d) {
+        result = isFrom
+          ? inputInstance.diff(instance, t.d, true)
+          : instance.diff(inputInstance, t.d, true)
+      }
+
+      let abs = rounding(Math.abs(result))
+      isFuture = result > 0
+
+      if (abs <= (t.r ?? Number.POSITIVE_INFINITY)) {
+        if (abs <= 1 && i > 0) t = thresholds[i - 1]
+        const format = locale[t.l]
+        if (postFormat) abs = Number.parseInt(postFormat(`${abs}`), 10)
+
+        out =
+          typeof format === 'string'
+            ? format.replace('%d', abs.toString())
+            : format(abs, withoutSuffix, t.l, isFuture)
+
+        break
+      }
+    }
+
+    if (withoutSuffix) return out
+
+    const suffix = isFuture ? locale.future : locale.past
+    return typeof suffix === 'function'
+      ? suffix(out, withoutSuffix, isFuture ? 'future' : 'past', isFuture)
+      : suffix.replace('%s', out)
+  }
+
+  const getNow = (self: EsDay) => (self['$conf'].utc ? esday.utc() : esday())
+
+  proto.to = function (this: EsDay, input: DateType, withoutSuffix?: boolean) {
+    return fromToBase(input, withoutSuffix ?? false, this, true)
+  }
+
+  proto.from = function (this: EsDay, input: DateType, withoutSuffix?: boolean) {
+    return fromToBase(input, withoutSuffix ?? false, this, false)
+  }
+
+  proto.toNow = function (this: EsDay, withoutSuffix?: boolean) {
+    return this.to(getNow(this), withoutSuffix)
+  }
+
+  proto.fromNow = function (this: EsDay, withoutSuffix?: boolean) {
+    return this.from(getNow(this), withoutSuffix)
+  }
+}
+
+export default plugin

--- a/src/plugins/relativeTime/index.ts
+++ b/src/plugins/relativeTime/index.ts
@@ -1,3 +1,18 @@
+/**
+ * RelativeTime adds .from .to .fromNow .toNow APIs to formats date to relative time strings (e.g. 3 hours ago).
+ *
+ * Time from now .fromNow(withoutSuffix?: boolean)
+ * Returns the string of relative time from now.
+ *
+ * Time from X .from(compared: Dayjs, withoutSuffix?: boolean)
+ * Returns the string of relative time from X.
+ *
+ * Time to now .toNow(withoutSuffix?: boolean)
+ * Returns the string of relative time to now.
+ *
+ * Time to X .to(compared: Dayjs, withoutSuffix?: boolean)
+ * Returns the string of relative time to X.
+ */
 import type { DateType, EsDay, EsDayPlugin } from 'esday'
 import { C } from '~/common'
 import type { Locale, RelativeTimeKeys } from '../locale'
@@ -23,7 +38,9 @@ const plugin: EsDayPlugin<{
 }> = (options, Class, esday) => {
   const proto = Class.prototype
 
-  const relObj: Locale['relativeTime'] = {
+  // Default relative time strings
+  // copy from locales/en.ts
+  const defaultRTDef: Locale['relativeTime'] = {
     future: 'in %s',
     past: '%s ago',
     s: 'a few seconds',
@@ -40,7 +57,7 @@ const plugin: EsDayPlugin<{
     yy: '%d years',
   }
 
-  const thresholds: Threshold[] = options.thresholds || [
+  const thresholds: Threshold[] = options.thresholds ?? [
     { l: 's', r: 44, d: C.SECOND },
     { l: 'm', r: 89 },
     { l: 'mm', r: 44, d: C.MIN },
@@ -54,7 +71,7 @@ const plugin: EsDayPlugin<{
     { l: 'yy', d: C.YEAR },
   ]
 
-  const rounding = options.rounding || Math.round
+  const rounding = options.rounding ?? Math.round
 
   function fromToBase(
     input: DateType,
@@ -68,7 +85,7 @@ const plugin: EsDayPlugin<{
       return C.INVALID_DATE_STRING
     }
 
-    const locale = instance.localeObject?.()?.relativeTime || relObj
+    const locale = instance.localeObject?.()?.relativeTime ?? defaultRTDef
     let result = 0
     let out = ''
     let isFuture = false

--- a/test/plugins/relativeTime.test.ts
+++ b/test/plugins/relativeTime.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, it, vi } from 'vitest'
 import { expectSame } from '../util'
 
 import { C } from '~/common'
-import { utcPlugin, relativeTimePlugin } from '~/plugins'
+import { relativeTimePlugin, utcPlugin } from '~/plugins'
 
 esday.extend(utcPlugin).extend(relativeTimePlugin)
 

--- a/test/plugins/relativeTime.test.ts
+++ b/test/plugins/relativeTime.test.ts
@@ -1,70 +1,49 @@
 import { esday } from 'esday'
-import moment from 'moment/min/moment-with-locales'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, it, vi } from 'vitest'
+import { expectSame } from '../util'
+
 import relativeTimePlugin from '~/plugins/relativeTime'
+import { C } from '~/common'
 
 esday.extend(relativeTimePlugin)
 
 describe('relativeTime plugin', () => {
-  it.each([
-    { input: esday().subtract(30, 'second') },
-    { input: esday().subtract(1, 'minute') },
-    { input: esday().subtract(5, 'minute') },
-    { input: esday().subtract(1, 'hour') },
-    { input: esday().subtract(3, 'hour') },
-    { input: esday().subtract(1, 'day') },
-    { input: esday().subtract(10, 'day') },
-    { input: esday().add(30, 'second') },
-    { input: esday().add(1, 'minute') },
-    { input: esday().add(5, 'day') },
-    { input: esday().add(1, 'year') },
-  ])('fromNow() output should match moment.fromNow()', ({ input }) => {
-    const esResult = input.fromNow()
-    const momentResult = moment(input.toDate()).fromNow()
+  const fakeTimeAsString = '2023-12-17T03:24:46.234'
+  const targeTimeAsString = '2024-08-14T12:00:00.000Z'
 
-    expect(esResult).toBe(momentResult)
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(fakeTimeAsString))
   })
 
-  it('toNow() should match moment.toNow()', () => {
-    const input = esday().add(3, 'hour')
-    const esResult = esday().to(input)
-    const momentResult = moment().to(moment(input.toDate()))
-
-    expect(esResult).toBe(momentResult)
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
-  it('from() and to() should match moment results', () => {
-    const now = esday()
-    const past = now.subtract(2, 'day')
-    const future = now.add(3, 'day')
-
-    expect(now.from(past)).toBe(moment(now.toDate()).from(moment(past.toDate())))
-    expect(now.to(future)).toBe(moment(now.toDate()).to(moment(future.toDate())))
+  it('fromNow', () => {
+    expectSame((esday) => esday().fromNow())
+    expectSame((esday) => esday().fromNow(true))
   })
 
-  it('should match moment when using withoutSuffix = true', () => {
-    const now = esday()
-    const future = now.add(1, 'hour')
-
-    const esResult = now.to(future, true)
-    const momentResult = moment(now.toDate()).to(moment(future.toDate()), true)
-
-    expect(esResult).toBe(momentResult)
+  it('toNow', () => {
+    expectSame((esday) => esday().toNow())
+    expectSame((esday) => esday().toNow(true))
   })
 
-  it('should match moment with invalid inputs', () => {
-    const invalidEs = esday('invalid')
-    const validEs = esday()
-    const invalidMoment = moment.invalid()
-    const validMoment = moment()
+  it('from', () => {
+    expectSame((esday) => esday().from(targeTimeAsString))
+    expectSame((esday) => esday().from(targeTimeAsString, true))
+  })
 
-    expect(invalidEs.from(validEs).toLowerCase()).toBe(
-      invalidMoment.from(validMoment).toLowerCase(),
-    )
-    expect(invalidEs.to(validEs).toLowerCase()).toBe(invalidMoment.to(validMoment).toLowerCase())
-    expect(validEs.from(invalidEs).toLowerCase()).toBe(
-      validMoment.from(invalidMoment).toLowerCase(),
-    )
-    expect(validEs.to(invalidEs).toLowerCase()).toBe(validMoment.to(invalidMoment).toLowerCase())
+  it('to', () => {
+    expectSame((esday) => esday().to(targeTimeAsString))
+    expectSame((esday) => esday().to(targeTimeAsString, true))
+  })
+
+  it('invalid input', () => {
+    expectSame((esday) => esday(C.INVALID_DATE).fromNow().toLowerCase())
+    expectSame((esday) => esday(C.INVALID_DATE).toNow().toLowerCase())
+    expectSame((esday) => esday(C.INVALID_DATE).from(targeTimeAsString).toLowerCase())
+    expectSame((esday) => esday(C.INVALID_DATE).to(targeTimeAsString).toLowerCase())
   })
 })

--- a/test/plugins/relativeTime.test.ts
+++ b/test/plugins/relativeTime.test.ts
@@ -2,10 +2,10 @@ import { esday } from 'esday'
 import { afterEach, beforeEach, describe, it, vi } from 'vitest'
 import { expectSame } from '../util'
 
-import relativeTimePlugin from '~/plugins/relativeTime'
 import { C } from '~/common'
+import { utcPlugin, relativeTimePlugin } from '~/plugins'
 
-esday.extend(relativeTimePlugin)
+esday.extend(utcPlugin).extend(relativeTimePlugin)
 
 describe('relativeTime plugin', () => {
   const fakeTimeAsString = '2023-12-17T03:24:46.234'
@@ -20,30 +20,38 @@ describe('relativeTime plugin', () => {
     vi.useRealTimers()
   })
 
-  it('fromNow', () => {
+  it('basic usage', () => {
     expectSame((esday) => esday().fromNow())
     expectSame((esday) => esday().fromNow(true))
-  })
-
-  it('toNow', () => {
     expectSame((esday) => esday().toNow())
     expectSame((esday) => esday().toNow(true))
-  })
-
-  it('from', () => {
     expectSame((esday) => esday().from(targeTimeAsString))
     expectSame((esday) => esday().from(targeTimeAsString, true))
-  })
-
-  it('to', () => {
     expectSame((esday) => esday().to(targeTimeAsString))
     expectSame((esday) => esday().to(targeTimeAsString, true))
   })
 
   it('invalid input', () => {
+    // moment.js will return 'Invalid date' for invalid input
+    // esday will return 'Invalid Date' for invalid input (align to Date.toString())
     expectSame((esday) => esday(C.INVALID_DATE).fromNow().toLowerCase())
     expectSame((esday) => esday(C.INVALID_DATE).toNow().toLowerCase())
     expectSame((esday) => esday(C.INVALID_DATE).from(targeTimeAsString).toLowerCase())
     expectSame((esday) => esday(C.INVALID_DATE).to(targeTimeAsString).toLowerCase())
+    expectSame((esday) => esday(C.INVALID_DATE).fromNow(true).toLowerCase())
+    expectSame((esday) => esday(C.INVALID_DATE).toNow(true).toLowerCase())
+    expectSame((esday) => esday(C.INVALID_DATE).from(targeTimeAsString, true).toLowerCase())
+    expectSame((esday) => esday(C.INVALID_DATE).to(targeTimeAsString, true).toLowerCase())
+  })
+
+  it('utc', () => {
+    expectSame((esday) => esday.utc().fromNow())
+    expectSame((esday) => esday.utc().toNow())
+    expectSame((esday) => esday.utc().from(targeTimeAsString))
+    expectSame((esday) => esday.utc().to(targeTimeAsString))
+    expectSame((esday) => esday.utc().fromNow(true))
+    expectSame((esday) => esday.utc().toNow(true))
+    expectSame((esday) => esday.utc().from(targeTimeAsString, true))
+    expectSame((esday) => esday.utc().to(targeTimeAsString, true))
   })
 })

--- a/test/plugins/relativeTime.test.ts
+++ b/test/plugins/relativeTime.test.ts
@@ -1,0 +1,70 @@
+import { esday } from 'esday'
+import moment from 'moment/min/moment-with-locales'
+import { describe, expect, it } from 'vitest'
+import relativeTimePlugin from '~/plugins/relativeTime'
+
+esday.extend(relativeTimePlugin)
+
+describe('relativeTime plugin', () => {
+  it.each([
+    { input: esday().subtract(30, 'second') },
+    { input: esday().subtract(1, 'minute') },
+    { input: esday().subtract(5, 'minute') },
+    { input: esday().subtract(1, 'hour') },
+    { input: esday().subtract(3, 'hour') },
+    { input: esday().subtract(1, 'day') },
+    { input: esday().subtract(10, 'day') },
+    { input: esday().add(30, 'second') },
+    { input: esday().add(1, 'minute') },
+    { input: esday().add(5, 'day') },
+    { input: esday().add(1, 'year') },
+  ])('fromNow() output should match moment.fromNow()', ({ input }) => {
+    const esResult = input.fromNow()
+    const momentResult = moment(input.toDate()).fromNow()
+
+    expect(esResult).toBe(momentResult)
+  })
+
+  it('toNow() should match moment.toNow()', () => {
+    const input = esday().add(3, 'hour')
+    const esResult = esday().to(input)
+    const momentResult = moment().to(moment(input.toDate()))
+
+    expect(esResult).toBe(momentResult)
+  })
+
+  it('from() and to() should match moment results', () => {
+    const now = esday()
+    const past = now.subtract(2, 'day')
+    const future = now.add(3, 'day')
+
+    expect(now.from(past)).toBe(moment(now.toDate()).from(moment(past.toDate())))
+    expect(now.to(future)).toBe(moment(now.toDate()).to(moment(future.toDate())))
+  })
+
+  it('should match moment when using withoutSuffix = true', () => {
+    const now = esday()
+    const future = now.add(1, 'hour')
+
+    const esResult = now.to(future, true)
+    const momentResult = moment(now.toDate()).to(moment(future.toDate()), true)
+
+    expect(esResult).toBe(momentResult)
+  })
+
+  it('should match moment with invalid inputs', () => {
+    const invalidEs = esday('invalid')
+    const validEs = esday()
+    const invalidMoment = moment.invalid()
+    const validMoment = moment()
+
+    expect(invalidEs.from(validEs).toLowerCase()).toBe(
+      invalidMoment.from(validMoment).toLowerCase(),
+    )
+    expect(invalidEs.to(validEs).toLowerCase()).toBe(invalidMoment.to(validMoment).toLowerCase())
+    expect(validEs.from(invalidEs).toLowerCase()).toBe(
+      validMoment.from(invalidMoment).toLowerCase(),
+    )
+    expect(validEs.to(invalidEs).toLowerCase()).toBe(validMoment.to(invalidMoment).toLowerCase())
+  })
+})


### PR DESCRIPTION
There's a difference between Dayjs and Moment observed during testing: Dayjs doesn’t validate whether the date is valid. When given an invalid date, it always returns 'a month ago', whereas Moment returns 'Invalid date'.

Currently, we return 'Invalid Date' (C.INVALID_DATE_STRING). Was it intentional not to use 'Invalid date' instead? I don't quite remember.