### PR TITLE
Docs: remove comment about 'this is a template' in tests of locales

### DIFF
--- a/test/locales/af.test.ts
+++ b/test/locales/af.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Afrikaans [af]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/am.test.ts
+++ b/test/locales/am.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Amharic [am]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ar-dz.test.ts
+++ b/test/locales/ar-dz.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Arabic (Algeria) [ar-DZ]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ar-iq.test.ts
+++ b/test/locales/ar-iq.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Arabic (Iraq) [ar-IQ]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ar-kw.test.ts
+++ b/test/locales/ar-kw.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Arabic (Kuwait) [ar-KW]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ar-ly.test.ts
+++ b/test/locales/ar-ly.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Arabic (Lybia) [ar-LY]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ar-ma.test.ts
+++ b/test/locales/ar-ma.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Arabic (Morocco) [ar-MA]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ar-sa.test.ts
+++ b/test/locales/ar-sa.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Arabic (Saudi Arabia) [ar-SA]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ar-tn.test.ts
+++ b/test/locales/ar-tn.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Arabic (Tunisia) [ar-TN]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ar.test.ts
+++ b/test/locales/ar.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Arabic [ar]'.
- *
- * This is a minimal test for a locale with preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales with preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/az.test.ts
+++ b/test/locales/az.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Azerbaijani [az]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/be.test.ts
+++ b/test/locales/be.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Belarusian [be]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/bg.test.ts
+++ b/test/locales/bg.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Bulgarian [bg]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/bi.test.ts
+++ b/test/locales/bi.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Bislama [bi]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/bm.test.ts
+++ b/test/locales/bm.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Bambara [bm]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/bn-bd.test.ts
+++ b/test/locales/bn-bd.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Bengali (Bangladesh) [bn-BD]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/bn.test.ts
+++ b/test/locales/bn.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Bengali [bn]'
- *
- * This is a minimal test for a locale with preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales with preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/bo.test.ts
+++ b/test/locales/bo.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Tibetan [bo]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/br.test.ts
+++ b/test/locales/br.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Breton [br]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/bs.test.ts
+++ b/test/locales/bs.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Bosnian [bs]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ca.test.ts
+++ b/test/locales/ca.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Catalan [ca]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/cs.test.ts
+++ b/test/locales/cs.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Czech [cs]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/cv.test.ts
+++ b/test/locales/cv.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Chuvash [cv]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/cy.test.ts
+++ b/test/locales/cy.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Welsh [cy]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/da.test.ts
+++ b/test/locales/da.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Danish [da]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/de-at.test.ts
+++ b/test/locales/de-at.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'German (Austria) [de-AT]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/de-ch.test.ts
+++ b/test/locales/de-ch.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'German (Switzerland) [de-CH]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/de.test.ts
+++ b/test/locales/de.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'German [de]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/dv.test.ts
+++ b/test/locales/dv.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Maldivian [dv]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/el.test.ts
+++ b/test/locales/el.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Greek [el]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/en-au.test.ts
+++ b/test/locales/en-au.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'English (Australia) [en-AU]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/en-ca.test.ts
+++ b/test/locales/en-ca.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'English (Canada) [en-CA]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/en-gb.test.ts
+++ b/test/locales/en-gb.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'English (United Kingdom) [en-GB]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/en-ie.test.ts
+++ b/test/locales/en-ie.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'English (Ireland) [en-IE]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/en-il.test.ts
+++ b/test/locales/en-il.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'English (Israel) [en-IL]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/en-in.test.ts
+++ b/test/locales/en-in.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'English (India) [en-IN]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/en-nz.test.ts
+++ b/test/locales/en-nz.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'English (New Zealand) [en-NZ]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/en-sg.test.ts
+++ b/test/locales/en-sg.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'English (Singapore) [en-SG]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/en-tt.test.ts
+++ b/test/locales/en-tt.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'English (Trinidad & Tobago) [en-TT]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/en-us.test.ts
+++ b/test/locales/en-us.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'English (United States) [en-US]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/en.test.ts
+++ b/test/locales/en.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'English [en]'.
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/eo.test.ts
+++ b/test/locales/eo.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Esperanto [eo]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/es-do.test.ts
+++ b/test/locales/es-do.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Spanish (Dominican Republic) [es-DO]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/es-mx.test.ts
+++ b/test/locales/es-mx.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Spanish (Mexico) [es-MX]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/es-pr.test.ts
+++ b/test/locales/es-pr.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Spanish (Puerto Rico) [es-PR]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/es-us.test.ts
+++ b/test/locales/es-us.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Spanish (United States) [es-US]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/es.test.ts
+++ b/test/locales/es.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Spanish [es]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/et.test.ts
+++ b/test/locales/et.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Estonian [et]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/eu.test.ts
+++ b/test/locales/eu.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Basque [eu]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/fa.test.ts
+++ b/test/locales/fa.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Persian [fa]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/fi.test.ts
+++ b/test/locales/fi.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Finnish [fi]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/fo.test.ts
+++ b/test/locales/fo.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Faroese [fo]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/fr-ca.test.ts
+++ b/test/locales/fr-ca.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'French (Canada) [fr-CA]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/fr-ch.test.ts
+++ b/test/locales/fr-ch.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'French (Switzerland) [fr-CH]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/fr.test.ts
+++ b/test/locales/fr.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'French [fr]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/fy.test.ts
+++ b/test/locales/fy.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Frisian [fy]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ga.test.ts
+++ b/test/locales/ga.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Irish or Irish Gaelic [ga]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/gd.test.ts
+++ b/test/locales/gd.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Scottish Gaelic [gd]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/gl.test.ts
+++ b/test/locales/gl.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Galician [gl]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/gom-deva.test.ts
+++ b/test/locales/gom-deva.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Konkani Devanagari script [gom-DEVA]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/gom-latn.test.ts
+++ b/test/locales/gom-latn.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Konkani Latin script [gom-LATN]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/gu.test.ts
+++ b/test/locales/gu.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Gujarati [gu]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/he.test.ts
+++ b/test/locales/he.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Hebrew [he]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/hi.test.ts
+++ b/test/locales/hi.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Hindi [hi]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/hr.test.ts
+++ b/test/locales/hr.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Croatian [hr]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ht.test.ts
+++ b/test/locales/ht.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Haitian Creole (Haiti) [ht]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/hu.test.ts
+++ b/test/locales/hu.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Hungarian [hu]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/hy-am.test.ts
+++ b/test/locales/hy-am.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Armenian [hy-AM]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/id.test.ts
+++ b/test/locales/id.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Indonesian [id]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/is.test.ts
+++ b/test/locales/is.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Icelandic [is]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/it-ch.test.ts
+++ b/test/locales/it-ch.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Italian (Switzerland) [it-CH]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/it.test.ts
+++ b/test/locales/it.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Italian [it]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ja.test.ts
+++ b/test/locales/ja.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Japanese [ja]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/jv.test.ts
+++ b/test/locales/jv.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Javanese [jv]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ka.test.ts
+++ b/test/locales/ka.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Georgian [ka]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/kk.test.ts
+++ b/test/locales/kk.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Kazakh [kk]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/km.test.ts
+++ b/test/locales/km.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Cambodian [km]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/kn.test.ts
+++ b/test/locales/kn.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Kannada [kn]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ko.test.ts
+++ b/test/locales/ko.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Korean [ko]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ku.test.ts
+++ b/test/locales/ku.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Kurdish [ku]'
- *
- * This is a minimal test for a locale with preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales with preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ky.test.ts
+++ b/test/locales/ky.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Kyrgyz [ky]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/lb.test.ts
+++ b/test/locales/lb.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Luxembourgish [lb]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/lo.test.ts
+++ b/test/locales/lo.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Lao [lo]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/lt.test.ts
+++ b/test/locales/lt.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Lithuanian [lt]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/lv.test.ts
+++ b/test/locales/lv.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Latvian [lv]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/me.test.ts
+++ b/test/locales/me.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Montenegrin [me]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/mi.test.ts
+++ b/test/locales/mi.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Maori [mi]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/mk.test.ts
+++ b/test/locales/mk.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Macedonian [mk]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ml.test.ts
+++ b/test/locales/ml.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Malayalam [ml]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/mn.test.ts
+++ b/test/locales/mn.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Mongolian [mn]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/mr.test.ts
+++ b/test/locales/mr.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Marathi [mr]'
- *
- * This is a minimal test for a locale with preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales with preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ms-my.test.ts
+++ b/test/locales/ms-my.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Malay [ms-MY]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ms.test.ts
+++ b/test/locales/ms.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Malay [ms]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/mt.test.ts
+++ b/test/locales/mt.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Maltese (Malta) [mt]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/my.test.ts
+++ b/test/locales/my.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Burmese [my]'
- *
- * This is a minimal test for a locale with preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales with preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/nb.test.ts
+++ b/test/locales/nb.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Norwegian Bokmål [nb]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ne.test.ts
+++ b/test/locales/ne.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Nepalese [ne]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/nl-be.test.ts
+++ b/test/locales/nl-be.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Dutch (Belgium) [nl-BE]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/nl.test.ts
+++ b/test/locales/nl.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Dutch [nl]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/nn.test.ts
+++ b/test/locales/nn.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Nynorsk [nn]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/oc-lnc.test.ts
+++ b/test/locales/oc-lnc.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Occitan, lengadocian dialecte [oc-LNC]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/pa-in.test.ts
+++ b/test/locales/pa-in.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Punjabi (India) [pa-IN]'
- *
- * This is a minimal test for a locale with preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales with preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/pl.test.ts
+++ b/test/locales/pl.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Polish [pl]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/pt-br.test.ts
+++ b/test/locales/pt-br.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Portuguese (Brazil) [pt-BR]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/pt.test.ts
+++ b/test/locales/pt.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Portuguese [pt]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/rn.test.ts
+++ b/test/locales/rn.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Kirundi [rn]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ro.test.ts
+++ b/test/locales/ro.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Romanian [ro]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ru.test.ts
+++ b/test/locales/ru.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Russian [ru]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/rw.test.ts
+++ b/test/locales/rw.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Kinyarwanda (Rwanda) [rw]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/sd.test.ts
+++ b/test/locales/sd.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Sindhi [sd]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/se.test.ts
+++ b/test/locales/se.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Northern Sami [se]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/si.test.ts
+++ b/test/locales/si.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Sinhalese [si]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/sk.test.ts
+++ b/test/locales/sk.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Slovak [sk]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/sl.test.ts
+++ b/test/locales/sl.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Slovenian [sl]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/sq.test.ts
+++ b/test/locales/sq.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Albanian [sq]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/sr-cyrl.test.ts
+++ b/test/locales/sr-cyrl.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Serbian Cyrillic [sr-CYRL]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/sr.test.ts
+++ b/test/locales/sr.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Serbian [sr]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ss.test.ts
+++ b/test/locales/ss.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'siSwati [ss]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/sv-fi.test.ts
+++ b/test/locales/sv-fi.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Finland Swedish [sv-FI]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/sv.test.ts
+++ b/test/locales/sv.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Swedish [sv]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/sw.test.ts
+++ b/test/locales/sw.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Swahili [sw]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ta.test.ts
+++ b/test/locales/ta.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Tamil [ta]'
- *
- * This is a minimal test for a locale with preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales with preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/te.test.ts
+++ b/test/locales/te.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Telugu [te]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/tet.test.ts
+++ b/test/locales/tet.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Tetun Dili (East Timor) [tet]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/tg.test.ts
+++ b/test/locales/tg.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Tajik [tg]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/th.test.ts
+++ b/test/locales/th.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Thai [th]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/tk.test.ts
+++ b/test/locales/tk.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Turkmen [tk]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/tl-ph.test.ts
+++ b/test/locales/tl-ph.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Tagalog (Philippines) [tl-PH]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/tlh.test.ts
+++ b/test/locales/tlh.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Klingon [tlh]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/tr.test.ts
+++ b/test/locales/tr.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Turkish [tr]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/tzl.test.ts
+++ b/test/locales/tzl.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Talossan [tzl]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/tzm-latn.test.ts
+++ b/test/locales/tzm-latn.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Central Atlas Tamazight Latin [tzm-LATN]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/tzm.test.ts
+++ b/test/locales/tzm.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Central Atlas Tamazight [tzm]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ug-cn.test.ts
+++ b/test/locales/ug-cn.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Uyghur (China) [ug-CN]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/uk.test.ts
+++ b/test/locales/uk.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Ukrainian [uk]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/ur.test.ts
+++ b/test/locales/ur.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Urdu [ur]'
- *
- * This is a minimal test for a locale with preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales with preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/uz-latn.test.ts
+++ b/test/locales/uz-latn.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Uzbek Latin [uz-LATN]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/uz.test.ts
+++ b/test/locales/uz.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Uzbek [uz]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/vi.test.ts
+++ b/test/locales/vi.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Vietnamese [vi]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/x-pseudo.test.ts
+++ b/test/locales/x-pseudo.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Pseudo [x-pseudo]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/yo.test.ts
+++ b/test/locales/yo.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Yoruba Nigeria [yo]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/zh-cn.test.ts
+++ b/test/locales/zh-cn.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Chinese (China) [zh-CN]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/zh-hk.test.ts
+++ b/test/locales/zh-hk.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Chinese (Hong Kong) [zh-HK]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/zh-tw.test.ts
+++ b/test/locales/zh-tw.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Chinese (Taiwan) [zh-TW]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/locales/zh.test.ts
+++ b/test/locales/zh.test.ts
@@ -1,9 +1,5 @@
 /**
  * Test for locale 'Chinese [zh]'
- *
- * This is a minimal test for a locale without preParse / postFormat.
- * This file should aso be used as a template for tests for
- * other locales without preParse / postFormat.
  */
 
 import { describe, expect, it } from 'vitest'


### PR DESCRIPTION
As a consequence of copy-and-paste all test files for the locales contain a segment about using this file as a template for tests,
This gets fixed by this pr.