### PR TITLE
Fix: adapt string 'Invalid date' to moment.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ esday('2024-12-10').set('year', 2025).add(1, 'month').isToday()
 - **default value for 'Start of Week' is 1 (as in ISO 8601)**: 'Start of Week' is 1 ('Monday').
 - **default value for 'Start of Year' is 4 (as in ISO 8601)**: 'Start of Year' is 4.
 - **clamping month on set**: when changing the month and the new month does not have enough days to keep the current day of month, esday behaves like moment.js and clamps to the end of the target month
+- **Invalid Date**: conforms to Moment.js and uses `Invalid date` instead of `Invalid Date`.
 
 ## Differences to Moment.js
 
 Esday uses moment@2.30.1 as api reference.
 
 - **toString**: conforms to Day.js and uses Date.toUTCString() (returning the date in RFC 7231 format 'ddd, DD MMM YYYY HH:mm:ss [GMT]') while moment uses the format 'ddd MMM DD YYYY HH:mm:ss [GMT]ZZ'.
-- **toISOString**: conforms to Day.js and returns 'Invalid Date' when called on an invalid date. In that case moment returns null (see [moment pr#3710](https://github.com/moment/moment/pull/3710)).
+- **toISOString**: conforms to Day.js and returns 'Invalid date' when called on an invalid date. In that case moment returns null (see [moment pr#3710](https://github.com/moment/moment/pull/3710)).
 
 ## Contribute
 

--- a/dev/templates/template-locale.ts
+++ b/dev/templates/template-locale.ts
@@ -48,6 +48,14 @@ const localeEn: Readonly<Locale> = {
     lll: 'MMM D, YYYY h:mm A',
     llll: 'ddd, MMM D, YYYY h:mm A',
   },
+  calendar: {
+    sameDay: '[Today at] LT',
+    nextDay: '[Tomorrow at] LT',
+    nextWeek: 'dddd [at] LT',
+    lastDay: '[Yesterday at] LT',
+    lastWeek: '[Last] dddd [at] LT',
+    sameElse: 'L',
+  },
   relativeTime: {
     future: 'in %s',
     past: '%s ago',

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,10 +44,11 @@ Currently there are the following plugins:
 - **Locale**: Locale  is a Plugin; no default locale! Dayjs uses 'en-US' as default.
 - **'Start of Week'**: Default 'Start of Week' is 1 ('Monday') as defined by ISO 8601. Dayjs uses 0 ('Sunday') as (as defined by the dafault locale 'en-US').
 - **'Start of Year'**: Default 'Start of Year' is 4 (Jan 4th must be in the 1st week of the year) as defined by ISO 8601. Dayjs uses 1 (Jan 1st) as (as defined by the dafault locale 'en-US').
+- **Invalid Date**: conforms to Moment.js and uses `Invalid date` instead of `Invalid Date`.
 
 ## Differences to Moment.js
 
 Esday uses moment@2.30.1 as api reference.
 
 - **toString**: conforms to Day.js and uses Date.toUTCString() (returning the date in RFC 7231 format 'ddd, DD MMM YYYY HH:mm:ss [GMT]') while moment uses the format 'ddd MMM DD YYYY HH:mm:ss [GMT]ZZ'.
-- **toISOString**: conforms to Day.js and returns 'Invalid Date' when called on an invalid date. In that case moment returns null (see [moment pr#3710](https://github.com/moment/moment/pull/3710)).
+- **toISOString**: conforms to Day.js and returns 'Invalid date' when called on an invalid date. In that case moment returns null (see [moment pr#3710](https://github.com/moment/moment/pull/3710)).

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -30,7 +30,7 @@ export const DAY_OF_MONTH = 'date' as const
 export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
 
 export const INVALID_DATE = new Date('')
-export const INVALID_DATE_STRING = 'Invalid Date'
+export const INVALID_DATE_STRING = 'Invalid date'
 
 // regex
 export const REGEX_PARSE_DEFAULT =

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,5 +1,6 @@
 import type { EsDay, FormattingTokenDefinitions } from 'esday'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { C } from '~/common'
 import { esday } from '~/core'
 
 describe('format', () => {
@@ -20,7 +21,7 @@ describe('format', () => {
   })
 
   it.each(['', 'otherString'])('invalid date created from "%s"', (value) => {
-    expect(esday(value).format()).toBe('Invalid Date')
+    expect(esday(value).format()).toBe(C.INVALID_DATE_STRING)
   })
 
   it.each([

--- a/test/plugins/relativeTime.test.ts
+++ b/test/plugins/relativeTime.test.ts
@@ -32,8 +32,6 @@ describe('relativeTime plugin', () => {
   })
 
   it('invalid input', () => {
-    // moment.js will return 'Invalid date' for invalid input
-    // esday will return 'Invalid Date' for invalid input (align to Date.toString())
     expectSame((esday) => esday(C.INVALID_DATE).fromNow().toLowerCase())
     expectSame((esday) => esday(C.INVALID_DATE).toNow().toLowerCase())
     expectSame((esday) => esday(C.INVALID_DATE).from(targeTimeAsString).toLowerCase())


### PR DESCRIPTION
Make 'Invalid date' identical to moment.js; dayjs uses 'Invalid Date', but this is grammatically wrong or references a Date object (which IMHO does not really make sense in most cases).