### PR TITLE
Pu: add a basic getter for utcOffset to core to avoid duplicated code in plugins - splves issue #100

### DIFF
--- a/src/core/EsDay.ts
+++ b/src/core/EsDay.ts
@@ -243,6 +243,27 @@ export class EsDay {
     return diffImpl(this, date, units, asFloat)
   }
 
+  /**
+   * Get the utcOffset of date in minutes.
+   * "Proxy" implementation (getter only); the full functionality including
+   * the setters is implemented in the plugin Utc.
+   * @param offset - offset to be set
+   * @param keepLocalTime - keep the current time when setting the offset
+   * @returns utcOffset of date in minutes (getter) or invalid date (setter)
+   */
+  utcOffset(): number
+  utcOffset(offset: number | string): EsDay
+  utcOffset(offset: number | string, keepLocalTime?: boolean): EsDay
+  utcOffset(offset?: number | string, _keepLocalTime?: boolean) {
+    if (offset !== undefined) {
+      // this is only here to satisfy the setter overload; setting the
+      // utcOffset requires the plugin Utc
+      return new EsDay(C.INVALID_DATE)
+    }
+
+    return -Math.round(this['$d'].getTimezoneOffset())
+  }
+
   get(units: UnitTypeCore) {
     return getUnitInDate(this.$d, units)
   }

--- a/src/core/Impl/diff.ts
+++ b/src/core/Impl/diff.ts
@@ -39,18 +39,6 @@ function absFloor(n: number): number {
   return n < 0 ? Math.ceil(n) || 0 : Math.floor(n)
 }
 
-/**
- * Get the utcOffset of date in minutes.
- * Use the utcOffset method from the utc plugin if that is loaded;
- * otherwise get it from the javascript Date object of date.
- * @param date - EsDay instance to inspect
- * @returns utcOffset of date in minutes
- */
-function utcOffset(date: EsDay): number {
-  const defaultOffset = -Math.round(date['$d'].getTimezoneOffset()) || 0
-  return 'utcOffset' in date ? date.utcOffset() : defaultOffset
-}
-
 export function diffImpl(
   that: EsDay,
   date: EsDay,
@@ -59,7 +47,7 @@ export function diffImpl(
 ): number {
   const diffInMs = that.valueOf() - date.valueOf()
   const diffInMonths = monthDiff(that, date)
-  const zoneDelta = (utcOffset(that) - utcOffset(date)) * C.MILLISECONDS_A_MINUTE
+  const zoneDelta = (that.utcOffset() - date.utcOffset()) * C.MILLISECONDS_A_MINUTE
   let result: number
 
   if (!isUndefined(units)) {

--- a/src/core/Impl/format.ts
+++ b/src/core/Impl/format.ts
@@ -4,18 +4,6 @@ import { C, isUndefined, padStart, padZoneStr } from '~/common'
 const formattingSeparatorsRegex = '\\[([^\\]]+)\\]'
 let formattingTokensRegex: RegExp
 
-/**
- * Get the utcOffset of date.
- * Use the utcOffset method from the utc plugin if that is loaded;
- * otherwise get it from the javascript Date object of date.
- * @param date - EsDay instance to inspect
- * @returns utcOffset of date
- */
-function utcOffset(date: EsDay): number {
-  const defaultOffset = -Math.round(date['$d'].getTimezoneOffset()) || 0
-  return 'utcOffset' in date ? date.utcOffset() : defaultOffset
-}
-
 export const formatTokensDefinitions: FormattingTokenDefinitions = {
   YY: (sourceDate: EsDay) => padStart(sourceDate.year(), 2, '0').slice(-2),
   YYYY: (sourceDate: EsDay) => padStart(sourceDate.year(), 4, '0'),
@@ -30,10 +18,9 @@ export const formatTokensDefinitions: FormattingTokenDefinitions = {
   s: (sourceDate: EsDay) => String(sourceDate.second()),
   ss: (sourceDate: EsDay) => padStart(sourceDate.second(), 2, '0'),
   SSS: (sourceDate: EsDay) => padStart(sourceDate.millisecond(), 3, '0'),
-  Z: (sourceDate: EsDay) => padZoneStr(utcOffset(sourceDate)),
+  Z: (sourceDate: EsDay) => padZoneStr(sourceDate.utcOffset()),
 }
 
-// Get regex from list of supported tokens
 /**
  * Compare 2 tokens for sorting.
  * Longer token and upper case token are sorted to the top.
@@ -60,6 +47,7 @@ function compareTokens(a: string, b: string) {
   // are equal
   return 0
 }
+// Get regex from list of supported tokens
 export function formattingTokensRegexFromDefinitions() {
   // we have to sort the keys to always catch the longest matches
   const tokenKeys = Object.keys(formatTokensDefinitions).sort(compareTokens)

--- a/src/plugins/advancedFormat/index.ts
+++ b/src/plugins/advancedFormat/index.ts
@@ -7,25 +7,13 @@
 import type { EsDay, EsDayPlugin, FormattingTokenDefinitions } from 'esday'
 import { padStart, padZoneStr } from '~/common'
 
-/**
- * Get the utcOffset of date.
- * Use the utcOffset method from the utc plugin if that is loaded;
- * otherwise get it from the javascript Date object of date.
- * @param date - EsDay instance to inspect
- * @returns utcOffset of date
- */
-function utcOffset(date: EsDay): number {
-  const defaultOffset = -Math.round(date['$d'].getTimezoneOffset()) || 0
-  return 'utcOffset' in date ? date.utcOffset() : defaultOffset
-}
-
 const advancedFormatPlugin: EsDayPlugin<{}> = (_, _dayClass, dayFactory) => {
   // Extend formatting tokens
   const additionalTokens: FormattingTokenDefinitions = {
     d: (sourceDate: EsDay) => sourceDate.day().toString(),
     S: (sourceDate: EsDay) => padStart(sourceDate.millisecond(), 3, '0').slice(0, 1),
     SS: (sourceDate: EsDay) => padStart(sourceDate.millisecond(), 3, '0').slice(0, 2),
-    ZZ: (sourceDate: EsDay) => padZoneStr(utcOffset(sourceDate)).replace(':', ''),
+    ZZ: (sourceDate: EsDay) => padZoneStr(sourceDate.utcOffset()).replace(':', ''),
     X: (sourceDate: EsDay) => sourceDate.unix().toString(),
     x: (sourceDate: EsDay) => sourceDate.valueOf().toString(),
     k: (sourceDate: EsDay) => (sourceDate.hour() !== 0 ? sourceDate.hour() : 24).toString(),

--- a/src/plugins/utc/index.ts
+++ b/src/plugins/utc/index.ts
@@ -46,9 +46,6 @@ declare module 'esday' {
     utc: (keepLocalTime?: boolean) => EsDay
     local: () => EsDay
     isUTC: () => boolean
-    utcOffset(): number
-    utcOffset(offset: number | string): EsDay
-    utcOffset(offset: number | string, keepLocalTime: boolean): EsDay
   }
 
   interface EsDayFactory {
@@ -70,13 +67,14 @@ const utcPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
   }
 
   const proto = dayClass.prototype
+
   // convert a date to utc
   proto.utc = function (keepLocalTime?: boolean) {
     const inst = this.clone()
     inst['$d'] = this.toDate()
     inst['$conf'].utc = true
     if (keepLocalTime) {
-      // TODO maybe the generated time does not exits in the current timezone; see momentjs
+      // TODO maybe the generated time does not exits in the current timezone; see moment.js
       return inst.add(this.utcOffset(), C.MIN)
     }
     return inst


### PR DESCRIPTION
Today there are "proxy" implementations of the utcOffset getter in several plugins (see issue #100).

This pr adds the signature of `utcOffset` (getter **and** setters) and implements a **minimal** getter that takes the utc offset from the `$d` Date object,

This implementation is overwritten by the utc plugin with the **full** implementation.