### PR TITLE
Refactor: simplify method postParse in plugins week, isoWeek and localizedParse

### DIFF
--- a/src/plugins/advancedParse/index.ts
+++ b/src/plugins/advancedParse/index.ts
@@ -358,6 +358,7 @@ function makeParser(format: string, isStrict: boolean): { parser: Parser; postPa
   ): Date => {
     let modifiedParsedDate = parsedDate
     for (let i = 0; i < postParseHandlers.length; i++) {
+      // TODO how could we set the context for the postParse handlers to 'this'?
       modifiedParsedDate = postParseHandlers[i](modifiedParsedDate, parsedElements, parseOptions)
     }
 

--- a/src/plugins/advancedParse/types.ts
+++ b/src/plugins/advancedParse/types.ts
@@ -1,4 +1,4 @@
-import type { SimpleType } from 'esday'
+import type { EsDay, SimpleType } from 'esday'
 
 declare module 'esday' {
   interface EsDayFactory {
@@ -51,14 +51,17 @@ export interface ParsedResultRaw {
 export type Parser = (input: string, isStrict: boolean, options: ParseOptions) => ParsedResultRaw
 
 /**
- * Fix created 'parsedDate' using the 'parsedElements'.
- * E.g. convert meridiem time (12h) to iso time (24h)
+ * Fix a created 'parsedDate' using the 'parsedElements'; can be used
+ * e.g. to convert meridiem time (12h) to iso time (24h).
+ * Must be called in the context of an EsDay instance.
+ * @param this - context for this function (required by the makeParser function)
  * @param parsedDate - the date created from 'parsedElements'
  * @param parsedElements - object containing the components of a parsed date
  * @param options - parsing options e.g. containing the locale to use
  * @returns updated parsed date
  */
 export type PostParser = (
+  this: EsDay,
   parsedDate: Date,
   parsedElements: ParsedElements,
   options: ParseOptions,

--- a/src/plugins/localizedParse/index.ts
+++ b/src/plugins/localizedParse/index.ts
@@ -91,42 +91,6 @@ function addAfternoon(isLowerCase: boolean) {
 }
 
 /**
- * Convert the hours to 24h format.
- * @param parsedDate - Date object returned by parsing function
- * @param parsedElements - object containing the components of a parsed date
- * @param parseOptions - parsing options e.g. containing the locale to use
- * @returns parsedDate with hours converted to 24h format
- */
-function postParseMeridiem(
-  parsedDate: Date,
-  parsedElements: ParsedElements,
-  parseOptions: ParseOptions,
-) {
-  const modifiedDate = parsedDate
-
-  // is this a valid date and do we have parsed a meridiem?
-  if (!Number.isNaN(parsedDate.valueOf()) && !isUndefined(parsedElements.afternoon)) {
-    let parsedHours: number
-    if (!parseOptions.isUtc) {
-      parsedHours = parsedDate.getHours()
-      if (parsedHours < 12 && parsedElements.afternoon) {
-        modifiedDate.setHours(parsedHours + 12)
-      } else if (parsedHours === 12 && !parsedElements.afternoon) {
-        modifiedDate.setHours(0)
-      }
-    } else {
-      parsedHours = parsedDate.getUTCHours()
-      if (parsedHours < 12 && parsedElements.afternoon) {
-        modifiedDate.setUTCHours(parsedHours + 12)
-      } else if (parsedHours === 12 && !parsedElements.afternoon) {
-        modifiedDate.setUTCHours(0)
-      }
-    }
-  }
-  return modifiedDate
-}
-
-/**
  * Parse day of month as ordinal number.
  * @param parsedElements - object containing the components of a parsed date
  * @param input - parsed component of a date, to be transformed and inserted in parsedElements
@@ -207,57 +171,6 @@ function addDayOfWeek(property: 'weekdays' | 'weekdaysShort' | 'weekdaysMin') {
 }
 
 /**
- * Verify that parsed date is the expected day of week.
- * @param parsedDate - Date object returned by parsing function
- * @param parsedElements - object containing the components of a parsed date
- * @param parseOptions - parsing options e.g. containing the locale to use
- * @returns parsedDate or invalid date (if day of week does not match)
- */
-function postParseDayOfWeek(
-  parsedDate: Date,
-  parsedElements: ParsedElements,
-  parseOptions: ParseOptions,
-) {
-  let modifiedDate = parsedDate
-
-  // is this a valid date and do we have parsed the day of week?
-  if (!Number.isNaN(parsedDate.valueOf()) && !isUndefined(parsedElements.dayOfWeek)) {
-    let parsedDay: number
-    if (!parseOptions.isUtc) {
-      parsedDay = parsedDate.getDay()
-    } else {
-      parsedDay = parsedDate.getUTCDay()
-    }
-    if (parsedDay !== parsedElements.dayOfWeek) {
-      modifiedDate = C.INVALID_DATE
-    }
-  }
-  return modifiedDate
-}
-
-/**
- * List of parsing tokens; the key of an entry in this list is
- * the token to be parsed and the value is a 3-entries-array with
- * the 1st entry being the regex for parsing in 'standard' mode,
- * the 2nd entry being the regex for parsing in 'strict' mode and
- * the 3rd entry being a function that will add the corresponding
- * value to an object containing all the date&time elements (year,
- * month, day, ...).
- */
-const parseTokensDefinitions: TokenDefinitions = {
-  h: [match1to2, match1to2, addHour],
-  hh: [match1to2, match2, addHour],
-  a: [matchWord, matchWord, addAfternoon(true), postParseMeridiem],
-  A: [matchWord, matchWord, addAfternoon(false), postParseMeridiem],
-  dd: [matchWord, matchWord, addDayOfWeek('weekdaysMin'), postParseDayOfWeek],
-  ddd: [matchWord, matchWord, addDayOfWeek('weekdaysShort'), postParseDayOfWeek],
-  dddd: [matchWord, matchWord, addDayOfWeek('weekdays'), postParseDayOfWeek],
-  Do: [matchWord, matchWord, addDayOfMonthOrdinal],
-  MMM: [matchWord, matchWord, addMonth('monthsShort')],
-  MMMM: [matchWord, matchWord, addMonth('months')],
-}
-
-/**
  * Replace locale dependent token in given format with values from locale definition
  * e.g. 'LTS' with 'h:mm:ss A'
  * @param format - original format (with locale dependent tokens)
@@ -275,6 +188,89 @@ function replaceLocaleTokens(format: string, currentLocale: Locale) {
 
 const localizedParsePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
   const proto = dayClass.prototype
+
+  /**
+   * Convert the hours to 24h format.
+   * Must be called in the context of an EsDay instance.
+   * @param this - context for this function (required for getting the $conf settings)
+   * @param parsedDate - Date object returned by parsing function
+   * @param parsedElements - object containing the components of a parsed date
+   * @returns parsedDate with hours converted to 24h format
+   */
+  function _postParseMeridiem(this: EsDay, parsedDate: Date, parsedElements: ParsedElements) {
+    const modifiedDate = parsedDate
+
+    // is this a valid date and do we have parsed a meridiem?
+    if (!Number.isNaN(parsedDate.valueOf()) && !isUndefined(parsedElements.afternoon)) {
+      let parsedHours: number
+      // @ts-expect-error isUtc method is only available when plugin Utc is loaded
+      if (!this.isUtc?.()) {
+        parsedHours = parsedDate.getHours()
+        if (parsedHours < 12 && parsedElements.afternoon) {
+          modifiedDate.setHours(parsedHours + 12)
+        } else if (parsedHours === 12 && !parsedElements.afternoon) {
+          modifiedDate.setHours(0)
+        }
+      } else {
+        parsedHours = parsedDate.getUTCHours()
+        if (parsedHours < 12 && parsedElements.afternoon) {
+          modifiedDate.setUTCHours(parsedHours + 12)
+        } else if (parsedHours === 12 && !parsedElements.afternoon) {
+          modifiedDate.setUTCHours(0)
+        }
+      }
+    }
+    return modifiedDate
+  }
+
+  /**
+   * Verify that parsed date is the expected day of week.
+   * Must be called in the context of an EsDay instance.
+   * @param this - context for this function (required for getting the $conf settings)
+   * @param parsedDate - Date object returned by parsing function
+   * @param parsedElements - object containing the components of a parsed date
+   * @returns parsedDate or invalid date (if day of week does not match)
+   */
+  function _postParseDayOfWeek(this: EsDay, parsedDate: Date, parsedElements: ParsedElements) {
+    let modifiedDate = parsedDate
+
+    // is this a valid date and do we have parsed the day of week?
+    if (!Number.isNaN(parsedDate.valueOf()) && !isUndefined(parsedElements.dayOfWeek)) {
+      let parsedDay: number
+      // HACK if (!parseOptions.isUtc) {
+      if (!this['$conf'].utc) {
+        parsedDay = parsedDate.getDay()
+      } else {
+        parsedDay = parsedDate.getUTCDay()
+      }
+      if (parsedDay !== parsedElements.dayOfWeek) {
+        modifiedDate = C.INVALID_DATE
+      }
+    }
+    return modifiedDate
+  }
+
+  /**
+   * List of parsing tokens; the key of an entry in this list is
+   * the token to be parsed and the value is a 3-entries-array with
+   * the 1st entry being the regex for parsing in 'standard' mode,
+   * the 2nd entry being the regex for parsing in 'strict' mode and
+   * the 3rd entry being a function that will add the corresponding
+   * value to an object containing all the date&time elements (year,
+   * month, day, ...).
+   */
+  const parseTokensDefinitions: TokenDefinitions = {
+    h: [match1to2, match1to2, addHour],
+    hh: [match1to2, match2, addHour],
+    a: [matchWord, matchWord, addAfternoon(true), _postParseMeridiem],
+    A: [matchWord, matchWord, addAfternoon(false), _postParseMeridiem],
+    dd: [matchWord, matchWord, addDayOfWeek('weekdaysMin'), _postParseDayOfWeek],
+    ddd: [matchWord, matchWord, addDayOfWeek('weekdaysShort'), _postParseDayOfWeek],
+    dddd: [matchWord, matchWord, addDayOfWeek('weekdays'), _postParseDayOfWeek],
+    Do: [matchWord, matchWord, addDayOfMonthOrdinal],
+    MMM: [matchWord, matchWord, addMonth('monthsShort')],
+    MMMM: [matchWord, matchWord, addMonth('months')],
+  }
 
   // add new parsing tokens to existing list of parsing tokens
   dayFactory.addParseTokenDefinitions(parseTokensDefinitions)

--- a/src/plugins/week/index.ts
+++ b/src/plugins/week/index.ts
@@ -7,21 +7,12 @@
  * This plugin requires the 'locale' plugin and a locale to be loaded.
  * For the 'wo' formatting token, the 'localizedFormat' plugin is required too.
  *
- * esday parameters in '$conf' defined in week plugin:
- *   parseOptions  ParseOptions object containing parsing options
- *
- * new esday parameters in '$conf.parseOptions':
- *   locale        name of the locale to use when parsing
- *   isUtc         evaluate date as utc
+ * To use the parsing tokens, the plugin AdvancedParse is required.
  */
 
-import { esday } from 'esday'
-import type { DateType, EsDay, EsDayPlugin, FormattingTokenDefinitions, UnitType } from 'esday'
+import type { EsDay, EsDayPlugin, FormattingTokenDefinitions, UnitType } from 'esday'
 import { C, isUndefined, padStart } from '~/common'
 import type { ParseOptions, ParsedElements, TokenDefinitions } from '../advancedParse/types'
-import { getLocale } from '../locale'
-
-const DEFAULT_LOCALE = 'en'
 
 const match1to2NoLeadingZero = /^[1-9]\d?/ // 1-99
 const match1 = /\d/ // 0 - 9
@@ -95,135 +86,108 @@ function twoDigitsYearUpdater(
   parsedElements['weekYear'] = parseTwoDigitYear(input)
 }
 
-/**
- * Create new esday from parsed Date object.
- * @param parsedDate - Date object returned by parsing function
- * @param parseOptions  - parsing options e.g. containing the locale to use
- * @returns Esday object matching the parsedDate
- */
-function parsedDateToEsday(parsedDate: Date, parseOptions: ParseOptions) {
-  let newEsday: EsDay
-  if (!parseOptions.isUtc) {
-    newEsday = esday(parsedDate)
-  } else {
-    newEsday = esday.utc(parsedDate)
-  }
-
-  // add locale name if exists
-  const localeName = parseOptions['locale']
-  if (!isUndefined(localeName)) {
-    newEsday['$conf']['$locale_name'] = localeName
-  }
-  return newEsday
-}
-
-/**
- * Set the week of the parsed date.
- * @param parsedDate - Date object returned by parsing function
- * @param parsedElements - object containing the components of a parsed date
- * @param parseOptions - parsing options e.g. containing the locale to use
- * @returns parsedDate with week set to parsed value
- */
-function postParseWeek(
-  parsedDate: Date,
-  parsedElements: ParsedElements,
-  parseOptions: ParseOptions,
-) {
-  let modifiedDate = parsedDate
-
-  // is this a valid date and do we have parsed the week?
-  // if the source string contains a valid day of month, the week
-  // is ignored (like moment.js does).
-  if (
-    !Number.isNaN(parsedDate.valueOf()) &&
-    !isUndefined(parsedElements.week) &&
-    isUndefined(parsedElements.day)
-  ) {
-    const newEsday: EsDay = parsedDateToEsday(parsedDate, parseOptions)
-    const parsedWeek = parsedElements.week as number
-    const modifiedEsday = newEsday.week(parsedWeek).weekday(0)
-    modifiedDate = modifiedEsday.toDate()
-  }
-  return modifiedDate
-}
-
-/**
- * Set the dayOfWeek of the parsed date.
- * @param parsedDate - Date object returned by parsing function
- * @param parsedElements - object containing the components of a parsed date
- * @param parseOptions - parsing options e.g. containing the locale to use
- * @returns parsedDate or invalid date (if day of week does not match)
- */
-function postParseDayOfWeek(
-  parsedDate: Date,
-  parsedElements: ParsedElements,
-  parseOptions: ParseOptions,
-) {
-  const newWeekday = parsedElements.weekday as number
-  if (!isUndefined(newWeekday) && newWeekday !== null && (newWeekday < 0 || newWeekday > 6)) {
-    return C.INVALID_DATE
-  }
-
-  let modifiedDate = parsedDate
-
-  // is this a valid date and do we have parsed the day of week?
-  // if the source string contains a valid day of month, the weekday
-  // is ignored (like moment.js does).
-  if (
-    !Number.isNaN(parsedDate.valueOf()) &&
-    !isUndefined(newWeekday) &&
-    isUndefined(parsedElements.day)
-  ) {
-    let newEsday: EsDay = parsedDateToEsday(parsedDate, parseOptions)
-    if (isUndefined(parsedElements.weekYear) && isUndefined(parsedElements.week)) {
-      newEsday = newEsday
-        .month(parseOptions.currentMonth as number)
-        .date(parseOptions.currentDay as number)
-    }
-    const modifiedEsday = newEsday.weekday(newWeekday)
-    modifiedDate = modifiedEsday.toDate()
-  }
-  return modifiedDate
-}
-
-/**
- * Set weekYear of parsed date.
- * @param parsedDate - Date object returned by parsing function
- * @param parsedElements - object containing the components of a parsed date
- * @param parseOptions - parsing options e.g. containing the locale to use
- * @returns parsedDate with weekYear set to parsed value
- */
-function postParseYear(
-  parsedDate: Date,
-  parsedElements: ParsedElements,
-  parseOptions: ParseOptions,
-) {
-  let modifiedDate = parsedDate
-
-  // is this a valid date and do we have parsed the weekYear?
-  if (!Number.isNaN(parsedDate.valueOf()) && !isUndefined(parsedElements.weekYear)) {
-    const newEsday: EsDay = parsedDateToEsday(parsedDate, parseOptions)
-    const parsedWeekYear = parsedElements.weekYear as number
-
-    if (Object.keys(parsedElements).length === 1) {
-      // we parsed isoYear only ('gg' or 'gggg')
-      let modifiedEsday = newEsday.weekYear(parsedWeekYear)
-      modifiedEsday = modifiedEsday
-        .year(parsedWeekYear)
-        .month(parseOptions.currentMonth as number)
-        .date(parseOptions.currentDay as number)
-        .weekday(0)
-      modifiedDate = modifiedEsday.toDate()
-    } else if (!isUndefined(parsedElements.week)) {
-      const modifiedEsday = newEsday.weekYear(parsedWeekYear)
-      modifiedDate = modifiedEsday.toDate()
-    }
-  }
-  return modifiedDate
-}
-
 const weekPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
   const proto = dayClass.prototype
+
+  /**
+   * Set the week of the parsed date.
+   * Must be called in the context of an EsDay instance.
+   * @param this - context for this function (required for getting the $conf settings)
+   * @param parsedDate - Date object returned by parsing function
+   * @param parsedElements - object containing the components of a parsed date
+   * @returns parsedDate with week set to parsed value
+   */
+  function _postParseWeek(this: EsDay, parsedDate: Date, parsedElements: ParsedElements) {
+    let modifiedDate = parsedDate
+
+    // if the source string contains a valid day of month, the week
+    // is ignored (like moment.js does).
+    if (
+      !Number.isNaN(parsedDate.valueOf()) &&
+      !isUndefined(parsedElements.week) &&
+      isUndefined(parsedElements.day)
+    ) {
+      const newEsday = dayFactory(parsedDate, { utc: this['$conf'].utc as boolean })
+      newEsday['$conf'] = structuredClone(this['$conf'])
+
+      const parsedWeek = parsedElements.week as number
+      const modifiedEsday = newEsday.week(parsedWeek).weekday(0)
+      modifiedDate = modifiedEsday.toDate()
+    }
+    return modifiedDate
+  }
+
+  /**
+   * Set the dayOfWeek of the parsed date.
+   * Must be called in the context of an EsDay instance.
+   * @param this - context for this function (required for getting the $conf settings)
+   * @param parsedDate - Date object returned by parsing function
+   * @param parsedElements - object containing the components of a parsed date
+   * @returns parsedDate or invalid date (if day of week does not match)
+   */
+  function _postParseDayOfWeek(this: EsDay, parsedDate: Date, parsedElements: ParsedElements) {
+    const newWeekday = parsedElements.weekday as number
+    if (!isUndefined(newWeekday) && newWeekday !== null && (newWeekday < 0 || newWeekday > 6)) {
+      return C.INVALID_DATE
+    }
+
+    let modifiedDate = parsedDate
+
+    // if the source string contains a valid day of month, the weekday
+    // is ignored (like moment.js does).
+    if (
+      !Number.isNaN(parsedDate.valueOf()) &&
+      !isUndefined(newWeekday) &&
+      isUndefined(parsedElements.day)
+    ) {
+      let newEsday = dayFactory(parsedDate, { utc: this['$conf'].utc as boolean })
+      newEsday['$conf'] = structuredClone(this['$conf'])
+
+      if (isUndefined(parsedElements.weekYear) && isUndefined(parsedElements.week)) {
+        const now = new Date()
+        newEsday = newEsday.month(now.getMonth()).date(now.getDate())
+      }
+      const modifiedEsday = newEsday.weekday(newWeekday)
+      modifiedDate = modifiedEsday.toDate()
+    }
+    return modifiedDate
+  }
+
+  /**
+   * Set weekYear of parsed date.
+   * Must be called in the context of an EsDay instance.
+   * @param this - context for this function (required for getting the $conf settings)
+   * @param parsedDate - Date object returned by parsing function
+   * @param parsedElements - object containing the components of a parsed date
+   * @returns parsedDate with weekYear set to parsed value
+   */
+  function _postParseYear(this: EsDay, parsedDate: Date, parsedElements: ParsedElements) {
+    let modifiedDate = parsedDate
+
+    // is this a valid date and do we have parsed the weekYear?
+    if (!Number.isNaN(parsedDate.valueOf()) && !isUndefined(parsedElements.weekYear)) {
+      const newEsday = dayFactory(parsedDate, { utc: this['$conf'].utc as boolean })
+      newEsday['$conf'] = structuredClone(this['$conf'])
+
+      const parsedWeekYear = parsedElements.weekYear as number
+
+      if (Object.keys(parsedElements).length === 1) {
+        const now = new Date()
+        // we parsed isoYear only ('gg' or 'gggg')
+        let modifiedEsday = newEsday.weekYear(parsedWeekYear)
+        modifiedEsday = modifiedEsday
+          .year(parsedWeekYear)
+          .month(now.getMonth())
+          .date(now.getDate())
+          .weekday(0)
+        modifiedDate = modifiedEsday.toDate()
+      } else if (!isUndefined(parsedElements.week)) {
+        const modifiedEsday = newEsday.weekYear(parsedWeekYear)
+        modifiedDate = modifiedEsday.toDate()
+      }
+    }
+    return modifiedDate
+  }
 
   // @ts-expect-error function is compatible with its overload
   proto.week = function (newWeek?: number) {
@@ -383,40 +347,13 @@ const weekPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
 
   // Add week related parsing tokens
   const parseTokensDefinitions: TokenDefinitions = {
-    w: [match1to2, match1to2NoLeadingZero, addWeekProperty('week'), postParseWeek], // isoWeek 1..52
-    ww: [match1to2, match2, addWeekProperty('week'), postParseWeek], // isoWeek 01..52
-    e: [match1to2, match1, addWeekProperty('weekday'), postParseDayOfWeek], // isoWeekday 1..7
-    gg: [match1to4, match2, twoDigitsYearUpdater, postParseYear], // isoWeekYear 70 .. 30
-    gggg: [match1to4, match4, addWeekProperty('weekYear'), postParseYear], // isoWeekYear 1970 .. 2030
+    w: [match1to2, match1to2NoLeadingZero, addWeekProperty('week'), _postParseWeek], // isoWeek 1..52
+    ww: [match1to2, match2, addWeekProperty('week'), _postParseWeek], // isoWeek 01..52
+    e: [match1to2, match1, addWeekProperty('weekday'), _postParseDayOfWeek], // isoWeekday 1..7
+    gg: [match1to4, match2, twoDigitsYearUpdater, _postParseYear], // isoWeekYear 70 .. 30
+    gggg: [match1to4, match4, addWeekProperty('weekYear'), _postParseYear], // isoWeekYear 1970 .. 2030
   }
   dayFactory.addParseTokenDefinitions?.(parseTokensDefinitions)
-
-  const oldParse = proto['parse']
-  proto['parse'] = function (d?: Exclude<DateType, EsDay>) {
-    // create required parseOptions
-    const isUtc = this['$conf'].utc as boolean
-    const parseOptions: ParseOptions = (this['$conf'].parseOptions as ParseOptions) ?? {}
-    parseOptions.isUtc = isUtc
-
-    // handle locale name(s) as argument; use the locale of 'this'
-    // as the default value, if no locale is given as 3rd calling
-    // parameter (1st parameter is the date string).
-    let currentLocale = this.localeObject?.() ?? DEFAULT_LOCALE
-    const arg2 = this['$conf'].args_2
-    if (!isUndefined(arg2) && typeof arg2 === 'string') {
-      currentLocale = getLocale(arg2)
-    }
-
-    parseOptions.locale = currentLocale.name
-
-    // for setting weekday we need the current month and day
-    // (in special situations)
-    const now = new Date()
-    parseOptions.currentMonth = now.getMonth()
-    parseOptions.currentDay = now.getDate()
-    this['$conf'].parseOptions = parseOptions
-    oldParse.call(this, d)
-  }
 }
 
 export default weekPlugin

--- a/test/plugins/localizedParse.utc.test.ts
+++ b/test/plugins/localizedParse.utc.test.ts
@@ -258,7 +258,7 @@ describe('localizedParse plugin - local mode using locale given as parameter', (
   ])(
     'parse in "en" with "$locale" as locale parameter',
     ({ sourceString, formatString, locale }) => {
-      expect(esday(sourceString, formatString, locale).isValid()).toBeTruthy()
+      expect(esday.utc(sourceString, formatString, locale).isValid()).toBeTruthy()
       expectSameResult((esday) => esday.utc(sourceString, formatString, locale))
     },
   )


### PR DESCRIPTION
Remove dependency from utc from the  plugins week, isoWeek and localizedParse.