### PR TITLE
Rrefactor: use structuredClone for a deep copy in Esday.clone()

### DIFF
--- a/src/core/EsDay.ts
+++ b/src/core/EsDay.ts
@@ -215,7 +215,7 @@ export class EsDay {
 
   clone() {
     const newInst = new EsDay(this.$d)
-    newInst.$conf = { ...this.$conf }
+    newInst.$conf = structuredClone(this.$conf)
     return newInst
   }
 


### PR DESCRIPTION
Just for consistency in the code base: use `structuredClone()` for a deep copy in `Esday.clone()`