### PR TITLE
Refactor: use javascript private properties where applicable

### DIFF
--- a/src/core/EsDay.ts
+++ b/src/core/EsDay.ts
@@ -35,20 +35,22 @@ export declare interface EsDay {
 
 export class EsDay {
   protected $d!: Date
+
   /**
    * mainly for plugin compatibility
    * store data such as locale name, utc mode, etc.
    */
   private $conf: SimpleObject = {}
+
   constructor(d: Exclude<DateType, EsDay>, conf?: SimpleObject) {
     if (!isUndefined(conf)) {
       this.$conf = structuredClone<SimpleObject>(conf)
     }
-    this.parse(d)
+    this.$parse(d)
   }
 
-  private parse(d: Exclude<DateType, EsDay>) {
-    this.$d = this.$parseImpl(d)
+  protected $parse(d: Exclude<DateType, EsDay>) {
+    this.$d = this.#parseImpl(d)
   }
 
   /**
@@ -129,7 +131,7 @@ export class EsDay {
    * @param parsedElement - element to be converted
    * @returns parsed element as number
    */
-  private $toNumber(parsedElement: string | number | undefined) {
+  #toNumber(parsedElement: string | number | undefined) {
     if (
       parsedElement === undefined ||
       (typeof parsedElement === 'string' && parsedElement.trim().length === 0)
@@ -147,7 +149,7 @@ export class EsDay {
    * @param parsedElement - element to be converted
    * @returns parsed element as number
    */
-  private $toMsNumber(parsedElement: string | number | undefined) {
+  #toMsNumber(parsedElement: string | number | undefined) {
     if (parsedElement === undefined) {
       return undefined
     }
@@ -163,7 +165,7 @@ export class EsDay {
     return parsedElement
   }
 
-  private $parseImpl(date?: Exclude<DateType, EsDay>): Date {
+  #parseImpl(date?: Exclude<DateType, EsDay>): Date {
     if (date instanceof Date) return new Date(date)
     if (date === null) return new Date(Number.NaN)
     if (isUndefined(date)) return new Date()
@@ -172,13 +174,13 @@ export class EsDay {
     if (typeof date === 'string' && !/Z$/i.test(date)) {
       const d = date.match(C.REGEX_PARSE_DEFAULT)
       if (d) {
-        const Y = this.$toNumber(d[1])
-        const M = this.$toNumber(d[2])
-        const D = this.$toNumber(d[3])
-        const h = this.$toNumber(d[4])
-        const m = this.$toNumber(d[5])
-        const s = this.$toNumber(d[6])
-        const ms = this.$toMsNumber(d[7])
+        const Y = this.#toNumber(d[1])
+        const M = this.#toNumber(d[2])
+        const D = this.#toNumber(d[3])
+        const h = this.#toNumber(d[4])
+        const m = this.#toNumber(d[5])
+        const s = this.#toNumber(d[6])
+        const ms = this.#toMsNumber(d[7])
         return this.dateFromDateComponents(Y, M, D, h, m, s, ms)
       }
     }
@@ -300,7 +302,7 @@ export class EsDay {
     return this.$d.toUTCString()
   }
 
-  private $set(unit: UnitTypeCore, values: number[]) {
+  protected $set(unit: UnitTypeCore, values: number[]) {
     if (prettyUnit(unit) === C.DAY) {
       setUnitInDate(this.$d, C.DAY_OF_MONTH, this.date() + (values[0] - this.day()))
     } else if (prettyUnit(unit) === C.MONTH) {

--- a/src/plugins/advancedParse/index.ts
+++ b/src/plugins/advancedParse/index.ts
@@ -461,8 +461,8 @@ const advancedParsePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
   // get regexp to separate format into formatting tokens and separators
   formattingTokensRegexFromDefinitions()
 
-  const oldParse = proto['parse']
-  proto['parse'] = function (d?: Exclude<DateType, EsDay>) {
+  const oldParse = proto['$parse']
+  proto['$parse'] = function (d?: Exclude<DateType, EsDay>) {
     const format = this['$conf'].args_1
     const arg2 = this['$conf'].args_2
     const arg3 = this['$conf'].args_3

--- a/src/plugins/locale/index.ts
+++ b/src/plugins/locale/index.ts
@@ -116,8 +116,8 @@ const localePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
     return inst
   }
 
-  const oldParse = dayClass.prototype['parse']
-  dayClass.prototype['parse'] = function (d: Exclude<DateType, EsDay>) {
+  const oldParse = dayClass.prototype['$parse']
+  dayClass.prototype['$parse'] = function (d: Exclude<DateType, EsDay>) {
     oldParse.call(this, d)
 
     // set locale name

--- a/src/plugins/localizedParse/index.ts
+++ b/src/plugins/localizedParse/index.ts
@@ -264,8 +264,8 @@ const localizedParsePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
   // add new parsing tokens to existing list of parsing tokens
   dayFactory.addParseTokenDefinitions(parseTokensDefinitions)
 
-  const oldParse = proto['parse']
-  proto['parse'] = function (d?: Exclude<DateType, EsDay>) {
+  const oldParse = proto['$parse']
+  proto['$parse'] = function (d?: Exclude<DateType, EsDay>) {
     if (!isString(d)) {
       oldParse.call(this, d)
       return


### PR DESCRIPTION
This is a minimal change: use the 'modern' (ES2020) syntax for private properties of a class:  
Replace `private $xxx` with `#xxx` for true private properties of a class