### PR TITLE
refactor: use 'createInstanceFromExist' instead of 'dayFactory'

### DIFF
--- a/src/plugins/isoWeek/index.ts
+++ b/src/plugins/isoWeek/index.ts
@@ -11,7 +11,7 @@
  */
 
 import type { EsDay, EsDayPlugin, FormattingTokenDefinitions, UnitType } from 'esday'
-import { C, isUndefined, padStart } from '~/common'
+import { C, createInstanceFromExist, isUndefined, padStart } from '~/common'
 import type { ParseOptions, ParsedElements, TokenDefinitions } from '../advancedParse/types'
 
 declare module 'esday' {
@@ -117,9 +117,7 @@ const isoWeekPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
       !isUndefined(parsedElements.isoWeek) &&
       isUndefined(parsedElements.day)
     ) {
-      const newEsday = dayFactory(parsedDate, { utc: this['$conf'].utc as boolean })
-      newEsday['$conf'] = structuredClone(this['$conf'])
-
+      const newEsday = createInstanceFromExist(parsedDate, this)
       const parsedIsoWeek = parsedElements.isoWeek as number
       const modifiedEsday = newEsday.isoWeek(parsedIsoWeek).isoWeekday(weekStart)
       modifiedDate = modifiedEsday.toDate()
@@ -145,9 +143,7 @@ const isoWeekPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
       !isUndefined(parsedElements.isoWeekday) &&
       isUndefined(parsedElements.month)
     ) {
-      const newEsday = dayFactory(parsedDate, { utc: this['$conf'].utc as boolean })
-      newEsday['$conf'] = structuredClone(this['$conf'])
-
+      const newEsday = createInstanceFromExist(parsedDate, this)
       const newIsoWeekday = parsedElements.isoWeekday as number
       const modifiedEsday = newEsday.isoWeekday(newIsoWeekday)
       modifiedDate = modifiedEsday.toDate()
@@ -168,9 +164,7 @@ const isoWeekPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
 
     // is this a valid date and do we have parsed the isoWeekYear?
     if (!Number.isNaN(parsedDate.valueOf()) && !isUndefined(parsedElements.isoWeekYear)) {
-      const newEsday = dayFactory(parsedDate, { utc: this['$conf'].utc as boolean })
-      newEsday['$conf'] = structuredClone(this['$conf'])
-
+      const newEsday = createInstanceFromExist(parsedDate, this)
       const parsedIsoWeekYear = parsedElements.isoWeekYear as number
 
       if (Object.keys(parsedElements).length === 1) {

--- a/src/plugins/localizedParse/index.ts
+++ b/src/plugins/localizedParse/index.ts
@@ -15,7 +15,7 @@
  */
 
 import type { DateType, EsDay, EsDayPlugin } from 'esday'
-import { C, isArray, isString, isUndefined } from '~/common'
+import { C, createInstanceFromExist, isArray, isString, isUndefined } from '~/common'
 import type {
   DayNames,
   DayNamesStandaloneFormat,
@@ -229,8 +229,7 @@ const localizedParsePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
 
     // is this a valid date and do we have parsed the day of week?
     if (!Number.isNaN(parsedDate.valueOf()) && !isUndefined(parsedElements.dayOfWeek)) {
-      const newEsday = dayFactory(parsedDate, { utc: this['$conf'].utc as boolean })
-      newEsday['$conf'] = structuredClone(this['$conf'])
+      const newEsday = createInstanceFromExist(parsedDate, this)
 
       if (newEsday.day() !== parsedElements.dayOfWeek) {
         modifiedDate = C.INVALID_DATE

--- a/src/plugins/week/index.ts
+++ b/src/plugins/week/index.ts
@@ -11,7 +11,7 @@
  */
 
 import type { EsDay, EsDayPlugin, FormattingTokenDefinitions, UnitType } from 'esday'
-import { C, isUndefined, padStart } from '~/common'
+import { C, createInstanceFromExist, isUndefined, padStart } from '~/common'
 import type { ParseOptions, ParsedElements, TokenDefinitions } from '../advancedParse/types'
 
 const match1to2NoLeadingZero = /^[1-9]\d?/ // 1-99
@@ -107,9 +107,7 @@ const weekPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
       !isUndefined(parsedElements.week) &&
       isUndefined(parsedElements.day)
     ) {
-      const newEsday = dayFactory(parsedDate, { utc: this['$conf'].utc as boolean })
-      newEsday['$conf'] = structuredClone(this['$conf'])
-
+      const newEsday = createInstanceFromExist(parsedDate, this)
       const parsedWeek = parsedElements.week as number
       const modifiedEsday = newEsday.week(parsedWeek).weekday(0)
       modifiedDate = modifiedEsday.toDate()
@@ -166,9 +164,7 @@ const weekPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
 
     // is this a valid date and do we have parsed the weekYear?
     if (!Number.isNaN(parsedDate.valueOf()) && !isUndefined(parsedElements.weekYear)) {
-      const newEsday = dayFactory(parsedDate, { utc: this['$conf'].utc as boolean })
-      newEsday['$conf'] = structuredClone(this['$conf'])
-
+      const newEsday = createInstanceFromExist(parsedDate, this)
       const parsedWeekYear = parsedElements.weekYear as number
 
       if (Object.keys(parsedElements).length === 1) {


### PR DESCRIPTION
Minimal change:  
use `createInstanceFromExist(d, this)` instead of `dayFactory(d, { utc: this['conf].utc })`.

This change makes code shorter and easier to read.