### PR TITLE
feat: add array input to esday.utc()

### DIFF
--- a/src/core/EsDay.ts
+++ b/src/core/EsDay.ts
@@ -69,6 +69,7 @@ export class EsDay {
 
   /**
    * Create a Date object from the date components (year, month, ...).
+   * The month is 1 based (1..12).
    * Potential hook for plugins to change the details of Date creation.
    * @param Y - year of date to create
    * @param M - year of date to create
@@ -184,7 +185,7 @@ export class EsDay {
     if (date === null) return new Date(Number.NaN)
     if (isUndefined(date)) return new Date()
     if (isEmptyObject(date)) return new Date()
-    if (Array.isArray(date)) return parseArrayToDate(date)
+    if (Array.isArray(date)) return parseArrayToDate.call(this, date)
     if (typeof date === 'string' && !/Z$/i.test(date)) {
       const d = date.match(C.REGEX_PARSE_DEFAULT)
       if (d) {

--- a/src/core/Impl/parse.ts
+++ b/src/core/Impl/parse.ts
@@ -1,11 +1,20 @@
+import type { EsDay } from 'esday'
 import type { Tuple } from '~/types/util-types'
 
-export function parseArrayToDate(dateArray: number[]) {
-  const dateArrayTuple: Tuple<number, 7> = [0, 0, 1, 0, 0, 0, 0]
+/**
+ * Create a Date object from an array of date components (year, month, ...).
+ * The month is 0 based (0..11).
+ * @param this - context to access the right function 'dateFromDateComponents'
+ * @param dateArray - array with date components (y, M, D, h, m, s ms)
+ * @returns Date object created from given array elements
+ */
+export function parseArrayToDate(this: EsDay, dateArray: number[]) {
+  const dateArrayTuple: Tuple<number, 7> = [0, 1, 1, 0, 0, 0, 0]
   dateArray.forEach((value, index) => {
     if (value !== undefined) {
-      dateArrayTuple[index] = value
+      // input: month=0..11; target: month=1..12
+      dateArrayTuple[index] = index !== 1 ? value : value + 1
     }
   })
-  return new Date(...dateArrayTuple)
+  return this.dateFromDateComponents(...dateArrayTuple)
 }

--- a/test/plugins/utc.test.ts
+++ b/test/plugins/utc.test.ts
@@ -190,6 +190,18 @@ describe('plugin utc', () => {
       expect(esday.utc(dateString).format()).toEqual('2018-09-06T19:34:28Z')
       expect(esday.utc(dateString).format()).toEqual(moment.utc(dateString).format())
     })
+
+    it.each([
+      { dateArray: [2024] },
+      { dateArray: [2024, 5] },
+      { dateArray: [2024, 5, 1] },
+      { dateArray: [2024, 5, 1, 13] },
+      { dateArray: [2024, 5, 1, 13, 52] },
+      { dateArray: [2024, 5, 1, 13, 52, 44] },
+      { dateArray: [2024, 5, 1, 13, 14, 15, 99] },
+    ])('parses $dateArray to date', ({ dateArray }) => {
+      expectSameResult((esday) => esday.utc(dateArray))
+    })
   })
 
   describe('parse (with format)', () => {


### PR DESCRIPTION
Add array of date components (year, month, day,...) to esday.utc(input).