### PR TITLE
fix: remove inaccessible part of updateLocale function

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -16,7 +16,7 @@ import isSameOrBeforePlugin from './isSameOrBefore'
 import isTodayPlugin from './isToday'
 import isoWeekPlugin from './isoWeek'
 import localePlugin from './locale'
-import { getLocale } from './locale'
+import { cloneLocale, getLocale } from './locale'
 import type {
   Calendar,
   CalendarPartial,
@@ -47,6 +47,7 @@ export {
   advancedFormatPlugin,
   advancedParsePlugin,
   calendarPlugin,
+  cloneLocale,
   dayOfYearPlugin,
   getLocale,
   isBetweenPlugin,

--- a/src/plugins/locale/index.ts
+++ b/src/plugins/locale/index.ts
@@ -21,12 +21,8 @@ export function unregisterLocale(name: string): void {
 
 function updateLocale(localeName: string, locale: Partial<Locale>): void {
   const existingLocale = getLocale(localeName)
-  if (existingLocale) {
-    const updatedLocale = { ...existingLocale, ...locale }
-    LocaleStore.set(localeName, updatedLocale)
-  } else {
-    throw new Error(`Locale "${localeName}" does not exist.`)
-  }
+  const updatedLocale = { ...existingLocale, ...locale }
+  LocaleStore.set(localeName, updatedLocale)
 }
 
 /**

--- a/test/plugins/localizedFormat.test.ts
+++ b/test/plugins/localizedFormat.test.ts
@@ -1,14 +1,13 @@
 import { esday } from 'esday'
-import { beforeEach, describe, it } from 'vitest'
-import { expectSame } from '../util'
-
 import moment from 'moment/min/moment-with-locales'
+import { beforeEach, describe, it } from 'vitest'
 import localeCa from '~/locales/ca'
 import localeDe from '~/locales/de'
 import localeEn from '~/locales/en'
 import localeHr from '~/locales/hr'
 import localeKa from '~/locales/ka'
 import { localePlugin, localizedFormatPlugin } from '~/plugins'
+import { expectSame } from '../util'
 
 esday.extend(localizedFormatPlugin).extend(localePlugin)
 esday


### PR DESCRIPTION
In the new function `updateLocale` here has been no test for the case that a locale does not exist.
Getting a locale will always return a Locale object; if the requested locale does not exist, esday (as momentjs) returns the default Locale.
Therefore the part of `updateLocale` that would throw an exception (what we do nowhere else in esday), will never be reached (and can therefore not be tested :-).

Fixed that minor point and added more tests for `updateLocale`.