### PR TITLE
Chore: add check for minimal coverage to ci pipeline to solve issue #120 - step 2

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Report Coverage
+name: "Report Coverage"
 
 # Prevent that corepack looks for latest version of pnpm
 # HACK to work around issue nodejs/corepack#625
@@ -19,8 +19,26 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout
+      - name: "Checkout"
         uses: actions/checkout@v4
+
+      - name: "Install Pnpm"
+        run: corepack enable
+
+      - name: "Setup Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: "Install dependencies"
+        run: pnpm install
+
+      - name: "Run tests"
+        run: npx vitest run --coverage.enabled --coverage.reporter=json --coverage.reporter=json-summary
+
+      - name: "rename coverage directory"
+        run: |
+          mv coverage coverage-main
 
       - name: "Download coverage artifacts of pull request"
         uses: actions/download-artifact@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: "Report coverage"
         uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          json-summary-compare-path: coverage-main/coverage-summary.json
+          vite-config-path: configs/vitest.config.ts

--- a/.github/workflows/test-node.yaml
+++ b/.github/workflows/test-node.yaml
@@ -24,48 +24,36 @@ jobs:
   test-on-node:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        include:
-          - branch: main
-            artifact: main
-          - branch: ${{ github.head_ref }}
-            artifact: pull-request
-
     permissions:
       # Required to checkout the code
       contents: read
 
     steps:
-      - name: Checkout
+      - name: "Checkout"
         uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.branch }}
-          ## Set repository to correctly checkout from forks
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - name: Install Pnpm
+      - name: "Install Pnpm"
         run: corepack enable
 
-      - name: Setup Node.js
+      - name: "Setup Node.js"
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
 
-      - name: Install dependencies
+      - name: "Install dependencies"
         run: pnpm install
 
-      - name: Run tests
+      - name: "Run tests"
         run: npx vitest run --coverage.enabled --coverage.reporter=json --coverage.reporter=json-summary
 
       - name: "Upload coverage"
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.artifact }}
+          name: coverage-pull-request
           path: coverage
 
       - name: "Upload vitest config"
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}-vitest.config.ts
+          name: pull-request-vitest.config.ts
           path: vitest.config.ts

--- a/.github/workflows/test-node.yaml
+++ b/.github/workflows/test-node.yaml
@@ -22,15 +22,27 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   test-on-node:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    strategy:
+      matrix:
+        include:
+          - branch: main
+            artifact: main
+          - branch: ${{ github.head_ref }}
+            artifact: pull-request
+
+    permissions:
+      # Required to checkout the code
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          ref: ${{ matrix.branch }}
+          ## Set repository to correctly checkout from forks
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Install Pnpm
         run: corepack enable
@@ -49,11 +61,11 @@ jobs:
       - name: "Upload coverage"
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-pull-request
+          name: coverage-${{ matrix.artifact }}
           path: coverage
 
       - name: "Upload vitest config"
         uses: actions/upload-artifact@v4
         with:
-          name: pull-request-vitest.config.ts
+          name: ${{ matrix.artifact }}-vitest.config.ts
           path: vitest.config.ts


### PR DESCRIPTION
Add the 2nd step to github ci pipeline that ensures that a pr does not reduce test coverage below 95%.
Together with "step 1" it should add a comment to a newly created pull request that shows the coverage of the project and the changes caused by this pull request - example:
![example](https://github.com/user-attachments/assets/a5d86b32-a512-4416-b4d4-ec12fea0ab52)

PS: I could not test the final step (add the coverage report to the new created pull request).