### PR TITLE
Fix: results of plugin relative time differ from moment.js

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",

--- a/dev/templates/template-locale.ts
+++ b/dev/templates/template-locale.ts
@@ -67,6 +67,8 @@ const localeEn: Readonly<Locale> = {
     hh: '%d hours',
     d: 'a day',
     dd: '%d days',
+    w: 'a week',
+    ww: '%d weeks',
     M: 'a month',
     MM: '%d months',
     y: 'a year',

--- a/docs/plugins/relativeTime.md
+++ b/docs/plugins/relativeTime.md
@@ -47,25 +47,34 @@ The breakdown of which string is displayed for each length of time is outlined i
 | 320 to 547 days (1.5 years) | y   | a year ago                                  |
 | 548 days+                   | yy  | 2 years ago ... 20 years ago                |
 
+The RelativeTime plugin uses a list of thresholds, which define, when a unit is considered a minute, an hour and so on. For example, by default more than 45 seconds is considered a minute, more than 22 hours is considered a day and so on.
+
 The used thresholds can be overwritten, when activating the plugin by using an object with a property named `thresholds` as second parameter.
 
 The default threshold list looks like this;
 ```typescript
-[
-    { key: 's', thresholdValue: 44, thresholdUnit: C.SECOND },
-    { key: 'ss', thresholdValue: 43, thresholdUnit: C.SECOND },
-    { key: 'm', thresholdValue: 89, thresholdUnit: C.SECOND },
-    { key: 'mm', thresholdValue: 44, thresholdUnit: C.MIN },
-    { key: 'h', thresholdValue: 89, thresholdUnit: C.MIN },
-    { key: 'hh', thresholdValue: 21, thresholdUnit: C.HOUR },
-    { key: 'd', thresholdValue: 35, thresholdUnit: C.HOUR },
-    { key: 'dd', thresholdValue: 25, thresholdUnit: C.DAY },
-    { key: 'M', thresholdValue: 45, thresholdUnit: C.DAY },
-    { key: 'MM', thresholdValue: 10, thresholdUnit: C.MONTH },
-    { key: 'y', thresholdValue: 17, thresholdUnit: C.MONTH },
-    { key: 'yy', thresholdUnit: C.YEAR },
-  ]
+{
+  ss: 44,
+  s: 45,
+  m: 45,
+  h: 22,
+  d: 26,
+  w: null,
+  M: 11,
+}
 ```
+
+| unit | meaning       | usage                                                      |
+| ---- | ------------- | ---------------------------------------------------------- |
+| ss   | a few seconds | least number of seconds to be counted in seconds, minus 1. |
+| s    | seconds       | least number of seconds to be considered a minute.         |
+| m    | minutes       | least number of minutes to be considered an hour.          |
+| h    | hours         | least number of hours to be considered a day.              |
+| d    | days          | least number of days to be considered a week.              |
+| w    | weeks         | least number of weeks to be considered a month. Not used by default. |
+| M    | months        | least number of months to be considered a year.            |
+
+By default, the unit 'w' is not used (set to null). It can be set it to a non-null value to activate it. Optionally 'd' can be set to a lower value, so that transitions from days to weeks get earlier.
 
 ## Examples
 ```typescript
@@ -101,20 +110,15 @@ import localeEn from 'esday/locales/en'
 esday.extend(localePlugin)
 esday.registerLocale(localeEn)
 const options = {
-  thresholds: [
-    { key: 's', thresholdValue: 44, thresholdUnit: C.SECOND },
-    { key: 'ss', thresholdValue: 43, thresholdUnit: C.SECOND },
-    { key: 'm', thresholdValue: 89, thresholdUnit: C.SECOND },
-    { key: 'mm', thresholdValue: 44, thresholdUnit: C.MIN },
-    { key: 'h', thresholdValue: 89, thresholdUnit: C.MIN },
-    { key: 'hh', thresholdValue: 21, thresholdUnit: C.HOUR },
-    { key: 'd', thresholdValue: 1, thresholdUnit: C.DAY }, // modified threshold
-    { key: 'dd', thresholdValue: 25, thresholdUnit: C.DAY },
-    { key: 'M', thresholdValue: 45, thresholdUnit: C.DAY },
-    { key: 'MM', thresholdValue: 10, thresholdUnit: C.MONTH },
-    { key: 'y', thresholdValue: 17, thresholdUnit: C.MONTH },
-    { key: 'yy', thresholdUnit: C.YEAR },
-  ] as Threshold[],
+  thresholds: {
+    ss: 44,
+    s: 45,
+    m: 50, // modified; default: 45
+    h: 22,
+    d: 26,
+    w: null,
+    M: 11,
+  } as ThresholdRelativeTime,
 }
 esday.extend(relativeTimePlugin, options)
 ```

--- a/src/plugins/locale/types.ts
+++ b/src/plugins/locale/types.ts
@@ -73,13 +73,6 @@ export interface Calendar {
 }
 export type CalendarPartial = Partial<Calendar>
 
-export type RelativeTimeElementFunction = (
-  timeValue: string | number,
-  withoutSuffix: boolean,
-  token: string,
-  isFuture: boolean,
-) => string
-
 export type RelativeTimeKeys =
   | 'future'
   | 'past'
@@ -91,10 +84,19 @@ export type RelativeTimeKeys =
   | 'hh'
   | 'd'
   | 'dd'
+  | 'w'
+  | 'ww'
   | 'M'
   | 'MM'
   | 'y'
   | 'yy'
+
+export type RelativeTimeElementFunction = (
+  timeValue: string | number,
+  withoutSuffix: boolean,
+  token: RelativeTimeKeys,
+  isFuture: boolean,
+) => string
 
 // Type definition of locale (usually a literal object)
 export interface Locale {

--- a/src/plugins/relativeTime/index.ts
+++ b/src/plugins/relativeTime/index.ts
@@ -54,6 +54,8 @@ const relativeTimePlugin: EsDayPlugin<{
     hh: '%d hours',
     d: 'a day',
     dd: '%d days',
+    w: 'a week',
+    ww: '%d weeks',
     M: 'a month',
     MM: '%d months',
     y: 'a year',
@@ -183,7 +185,12 @@ const relativeTimePlugin: EsDayPlugin<{
     out =
       typeof format === 'string'
         ? format.replace('%d', `${outputDiffAbs}`)
-        : format(outputDiffAbs, withoutSuffix, selectedKeyAndValue.key, isFuture)
+        : format(
+            outputDiffAbs,
+            withoutSuffix,
+            selectedKeyAndValue.key as RelativeTimeKeys,
+            isFuture,
+          )
 
     // transform the result to locale form
     const postFormat = locale?.postFormat

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       esday: `${path.resolve(__dirname, 'src')}`,
     },
     coverage: {
-      exclude: [...configDefaults.exclude, 'dev/**', 'scripts/**'],
+      exclude: [...configDefaults.exclude, 'dev/**', 'scripts/**', 'tsdown.config.ts'],
       reporter: ['text', 'json', 'json-summary', 'html'],
       reportOnFailure: true,
       thresholds: {


### PR DESCRIPTION
While working on the plugin Duration, I found that the output of moment.js differs from output of plugin RelativeTime.

Added more test to find the differences and reworked basic parts of the plugin RelativeTime