### PR TITLE
build: fix file types in published version 0.6.2 - create new version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,12 @@
 {
   "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
   "editor.defaultFormatter": "biomejs.biome",
   "editor.codeActionsOnSave": {
     "source.fixAll.biome": "explicit",
     "source.fixAll.stylelint": "always",
     "source.organizeImports.biome": "explicit"
   },
-  "typescript.tsdk": "node_modules/typescript/lib",
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
@@ -32,6 +32,6 @@
   "[graphql]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
-  "editor.formatOnPaste": true,
-  "emmet.showExpandedAbbreviation": "never"
+  "emmet.showExpandedAbbreviation": "never",
+  "js/ts.tsdk.path": "node_modules\\typescript\\lib"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [0.6.3](https://github.com/BePo65/esday/compare/v0.6.2...v0.6.3) (2026-03-08)
+
 ## [0.6.2](https://github.com/BePo65/esday/compare/v0.6.1...v0.6.2) (2026-03-03)
 
 ## [0.6.1](https://github.com/BePo65/esday/compare/v0.6.0...v0.6.1) (2026-03-03)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esday",
   "type": "module",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "packageManager": "pnpm@10.30.2",
   "description": "A simple date library fully written in TypeScript",
   "license": "MIT",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   target: 'es2020',
-  platform: 'node',
+  platform: 'neutral',
   clean: true,
   dts: true,
   entry: ['src/index.ts', 'src/plugins/*/index.ts', 'src/locales/*.ts'],


### PR DESCRIPTION
+ the published version 0.6.2 contains .mjs and .d.mts files (result of new version of tsdown); fixed
+ create a new release (0.6.3)