### PR TITLE
refactor: add properties type to $conf parameter - resolves #41

### DIFF
--- a/src/core/EsDay.ts
+++ b/src/core/EsDay.ts
@@ -21,6 +21,7 @@ import type {
   UnitYears,
 } from '~/common/units'
 import type {
+  ConfigurationObject,
   DateType,
   UnitsObjectTypeAddSub,
   UnitsObjectTypeSet,
@@ -54,7 +55,7 @@ export class EsDay {
    * mainly for plugin compatibility
    * store data such as locale name, utc mode, etc.
    */
-  private $conf: SimpleObject = {}
+  private $conf: ConfigurationObject = {}
 
   constructor(d: Exclude<DateType, EsDay>, conf?: SimpleObject) {
     if (!isUndefined(conf)) {

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -4,7 +4,7 @@ import type { SimpleObject, SimpleType } from '~/types/util-types'
 import { EsDay } from './EsDay'
 import { addFormatTokenDefinitions } from './Impl/format'
 
-// @ts-expect-error plugin declare may cause ts-type-checke error, but it's ok
+// @ts-expect-error plugin declare may cause ts-type-check error, but it's ok
 const esday: EsDayFactory = (
   d?: DateType,
   ...others: (SimpleType | string[] | { [key: string]: SimpleType })[]
@@ -26,10 +26,11 @@ const esday: EsDayFactory = (
   })
   const result = new EsDay(d, conf)
 
-  // remove properties required for parsing only from $conf
+  // remove properties required for parsing-only from $conf
   const resultConf = result['$conf']
   for (const property in resultConf) {
     if (property.startsWith('args_')) {
+      // @ts-expect-error as we delete properties from a literal object
       delete resultConf[property]
     }
   }

--- a/src/plugins/advancedParse/types.ts
+++ b/src/plugins/advancedParse/types.ts
@@ -7,6 +7,10 @@ declare module 'esday' {
      */
     addParseTokenDefinitions: (newTokens: TokenDefinitions) => void
   }
+
+  interface ConfigurationObject {
+    parseOptions?: ParseOptions
+  }
 }
 
 export interface ParsedElements {

--- a/src/plugins/locale/index.ts
+++ b/src/plugins/locale/index.ts
@@ -113,10 +113,10 @@ export function cloneLocale(source: Locale): Locale {
 
 function getSetPrivateLocaleName(inst: EsDay, newLocaleName?: string): string {
   if (newLocaleName) {
-    inst['$conf']['localeName'] = newLocaleName
+    inst['$conf'].localeName = newLocaleName
   }
 
-  return (inst['$conf']['localeName'] as string) || ''
+  return inst['$conf'].localeName || ''
 }
 
 const localePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {

--- a/src/plugins/locale/types.ts
+++ b/src/plugins/locale/types.ts
@@ -28,6 +28,10 @@ declare module 'esday' {
     // update locale object in list of available Locales
     updateLocale: (localeName: string, newLocale: Partial<Locale>) => EsDayFactory
   }
+
+  interface ConfigurationObject {
+    localeName?: string
+  }
 }
 
 export type DayNames<T = string> = ReadonlyTuple<T, 7>

--- a/src/plugins/localizedParse/index.ts
+++ b/src/plugins/localizedParse/index.ts
@@ -256,7 +256,7 @@ const localizedParsePlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
     updateParsingPatternsFromLocale(parseTokensDefinitions, currentLocale)
 
     // create required parseOptions
-    const parseOptions: ParseOptions = (this['$conf'].parseOptions as ParseOptions) ?? {}
+    const parseOptions: ParseOptions = this['$conf'].parseOptions ?? {}
     parseOptions.locale = currentLocale.name
     this['$conf'].parseOptions = parseOptions
 

--- a/src/plugins/timezone/index.ts
+++ b/src/plugins/timezone/index.ts
@@ -478,7 +478,7 @@ const timezonePLugin: EsDayPlugin<{}> = (_, dayClass, esdayFactory) => {
     }
 
     if (this['$conf']?.timezone) {
-      const timezone = this['$conf'].timezone as string
+      const timezone = this['$conf'].timezone
       const dateComponents = timestampToDateTimeComponents(this.valueOf(), timezone)
 
       if (normalizedUnit === C.MS) {

--- a/src/plugins/timezone/types.ts
+++ b/src/plugins/timezone/types.ts
@@ -25,4 +25,8 @@ declare module 'esday' {
       guess: () => string
     }
   }
+
+  interface ConfigurationObject {
+    timezone?: string
+  }
 }

--- a/src/plugins/utc/index.ts
+++ b/src/plugins/utc/index.ts
@@ -45,6 +45,12 @@ declare module 'esday' {
       ...others: (SimpleType | string[] | { [key: string]: SimpleType })[]
     ) => EsDay
   }
+
+  interface ConfigurationObject {
+    utc?: boolean
+    utcOffset?: number
+    localOffset?: number
+  }
 }
 
 function offsetFromString(value = '') {

--- a/src/plugins/week/index.ts
+++ b/src/plugins/week/index.ts
@@ -189,7 +189,7 @@ const weekPlugin: EsDayPlugin<{}> = (_, dayClass, dayFactory) => {
       isUndefined(parsedElements.date)
     ) {
       let newEsday = dayFactory(parsedDate, {
-        utc: this['$conf'].utc as boolean,
+        utc: this['$conf'].utc,
       })
       newEsday['$conf'] = structuredClone(this['$conf'])
 

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -94,3 +94,10 @@ export type ParsingObjectPlurals = {
   milliseconds?: number | string
 }
 export type ParsingObject = ParsingObjectShort | ParsingObjectLong | ParsingObjectPlurals
+
+// Type for configuration parameters of plugins
+export interface ConfigurationObject {
+  args_1?: SimpleType | string[] | Record<string, SimpleType>
+  args_2?: SimpleType | string[] | Record<string, SimpleType>
+  args_3?: SimpleType | string[] | Record<string, SimpleType>
+}


### PR DESCRIPTION
change type of `$conf` from a generic type to using an interface with types defined in core and plugins that add new properties.